### PR TITLE
[MO] - allow tags to push to the next and retrict release branch to d…

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -33,8 +33,6 @@ jobs:
 
       - bash: mvn clean verify
         env:
-          STRIMZI_TEST_CONTAINER_KAFKA_VERSION: 3.0.0
-          STRIMZI_TEST_CONTAINER_IMAGE_VERSION: latest
           # Test container optimization
           TESTCONTAINERS_RYUK_DISABLED: TRUE
           TESTCONTAINERS_CHECKS_DISABLE: TRUE
@@ -47,7 +45,7 @@ jobs:
           NEXUS_USERNAME: $(NEXUS_USERNAME)
           NEXUS_PASSWORD: $(NEXUS_PASSWORD)
         displayName: "Push artifacts to Nexus repository"
-        condition: and(succeeded(), or(eq(variables['build.sourceBranch'], 'refs/heads/main'), startsWith(variables['build.sourceBranch'], 'refs/heads/release-')))
+        condition: and(succeeded(), or(eq(variables['build.sourceBranch'], 'refs/heads/main'), startsWith(variables['build.sourceBranch'], 'refs/tags/')))
 
       - task: PublishTestResults@2
         inputs:


### PR DESCRIPTION
…o so

This PR changes the last phase of pushing to the Nexus. Currently, we pushed artefacts when something new happened in `release-` branches. Now we do it only if it's `tag` (i.e., 0.100.0-rc1) and so on

Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>