### PR TITLE
[MO] - restrict KRaft for Kafka 2.8.1

### DIFF
--- a/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
@@ -102,6 +102,7 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
             }
         } catch (InterruptedException | ExecutionException e) {
             LOGGER.error("Error occurred during retrieving of image name provider", e);
+            throw new RuntimeException(e);
         }
         // we need it for the startZookeeper(); and startKafka(); to run container before...
         super.setCommand("sh", "-c", "while [ ! -f " + STARTER_SCRIPT + " ]; do sleep 0.1; done; " + STARTER_SCRIPT);

--- a/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 
 /**
@@ -92,8 +93,15 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
 
     @Override
     protected void doStart() {
-        if (!imageNameProvider.isDone()) {
-            imageNameProvider.complete(KafkaVersionService.strimziTestContainerImageName(kafkaVersion));
+        if (!this.imageNameProvider.isDone()) {
+            this.imageNameProvider.complete(KafkaVersionService.strimziTestContainerImageName(this.kafkaVersion));
+        }
+        try {
+            if (this.useKraft && ((this.kafkaVersion != null && this.kafkaVersion.equals("2.8.1")) || this.imageNameProvider.get().contains("2.8.1"))) {
+                throw new UnsupportedKraftKafkaVersionException("Specified Kafka version " + this.kafkaVersion + " is not supported in KRaft mode.");
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            LOGGER.error("Error occurred during retrieving of image name provider", e);
         }
         // we need it for the startZookeeper(); and startKafka(); to run container before...
         super.setCommand("sh", "-c", "while [ ! -f " + STARTER_SCRIPT + " ]; do sleep 0.1; done; " + STARTER_SCRIPT);

--- a/src/main/java/io/strimzi/test/container/UnsupportedKraftKafkaVersionException.java
+++ b/src/main/java/io/strimzi/test/container/UnsupportedKraftKafkaVersionException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.test.container;
+
+/**
+ * Provides a handler, when user specifies unsupported Kafka version with Kraft mode enabled
+ * {@link StrimziKafkaContainer#withKraft()}.
+ */
+public class UnsupportedKraftKafkaVersionException extends RuntimeException {
+
+    /**
+     * {@link UnsupportedKraftKafkaVersionException} used for handling situation, when
+     * user specifies unsupported Kafka version with Kraft mode enabled.
+     *
+     * @param message specific message to throw
+     */
+    public UnsupportedKraftKafkaVersionException(String message) {
+        super(message);
+    }
+
+    /**
+     * {@link UnsupportedKraftKafkaVersionException} used for handling situation, when
+     * user specifies unsupported Kafka version with Kraft mode enabled.
+     *
+     * @param cause specific cause to throw
+     */
+    public UnsupportedKraftKafkaVersionException(Throwable cause) {
+        super(cause);
+    }
+}


### PR DESCRIPTION
This PR restrict usage of KRaft for Kafka `2.8.1` and it's allowed only for `3.x.x` Kafka versions. Moreover, I have added tests cases for sanity checks. 

Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>