### PR TITLE
Controller listens on the localhost instead of container host

### DIFF
--- a/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
@@ -179,7 +179,7 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
 
         if (this.useKraft) {
             // adding Controller listener for Kraft mode
-            kafkaListeners.append(",").append("CONTROLLER").append("://").append(getContainerIpAddress()).append(":").append("9094");
+            kafkaListeners.append(",").append("CONTROLLER://localhost:9094");
             kafkaListenerSecurityProtocol.append(",").append("CONTROLLER:PLAINTEXT");
         }
 


### PR DESCRIPTION
When container host IP is not on localhost kraft containers fail on startup.