### PR TITLE
[MO] - `StrimziKafkaCluster` allow to specify configuration via Unmodif…

### DIFF
--- a/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
@@ -67,7 +67,7 @@ public class StrimziKafkaCluster implements Startable {
         defaultKafkaConfigurationForMultiNode.put("transaction.state.log.replication.factor", String.valueOf(internalTopicReplicationFactor));
         defaultKafkaConfigurationForMultiNode.put("transaction.state.log.min.isr", String.valueOf(internalTopicReplicationFactor));
 
-        additionalKafkaConfiguration.putAll(defaultKafkaConfigurationForMultiNode);
+        defaultKafkaConfigurationForMultiNode.putAll(additionalKafkaConfiguration);
 
         // multi-node set up
         this.brokers = IntStream
@@ -77,7 +77,7 @@ public class StrimziKafkaCluster implements Startable {
                 // adding broker id for each kafka container
                 StrimziKafkaContainer kafkaContainer = new StrimziKafkaContainer()
                     .withBrokerId(brokerId)
-                    .withKafkaConfigurationMap(additionalKafkaConfiguration)
+                    .withKafkaConfigurationMap(defaultKafkaConfigurationForMultiNode)
                     .withExternalZookeeperConnect("zookeeper:" + StrimziZookeeperContainer.ZOOKEEPER_PORT)
                     .withNetwork(this.network)
                     .withNetworkAliases("broker-" + brokerId)


### PR DESCRIPTION
…iableMap

This PR adds the option to specify additional configuration via `Map.of/UnmodifiableMap`.  Currently, if someone wants to specify the additional configuration to `StrimziKafkaCluster` it throws:
```
java.lang.UnsupportedOperationException
	at java.base/java.util.ImmutableCollections.uoe(ImmutableCollections.java:72)
	at java.base/java.util.ImmutableCollections$AbstractImmutableMap.putAll(ImmutableCollections.java:732)
	at io.strimzi.test.container.StrimziKafkaCluster.<init>(StrimziKafkaCluster.java:70)
	at io.strimzi.operator.cluster.operator.assembly.KafkaConnectApiTest.before(KafkaConnectApiTest.java:100)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:688)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
```

Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>