### PR TITLE
[MO] - `StrimziZookeeperContainer` -> connnect string method

### DIFF
--- a/src/main/java/io/strimzi/test/container/StrimziZookeeperContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziZookeeperContainer.java
@@ -115,4 +115,12 @@ public class StrimziZookeeperContainer extends GenericContainer<StrimziZookeeper
         return this;
     }
 
+    /**
+     * Provides host and mapped port, by which it connects to the ZooKeeper instance
+     *
+     * @return zookeeper connect string `host:port`
+     */
+    public String getConnectString() {
+        return this.getHost() + ":" + this.getFirstMappedPort();
+    }
 }


### PR DESCRIPTION
This PR adding a method to the `StrimziZookeeperContainer`, which provides a string representation of `host:port` to be able to connect to the running ZooKeeper instance.

Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>