### PR TITLE
[MO] - expose internal ZooKeeper to be able connect via external comp…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>io.strimzi</groupId>
     <artifactId>strimzi-test-container</artifactId>
     <packaging>jar</packaging>
-    <version>0.102.0-SNAPSHOT</version>
+    <version>0.101.0-SNAPSHOT</version>
 
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>io.strimzi</groupId>
     <artifactId>strimzi-test-container</artifactId>
     <packaging>jar</packaging>
-    <version>0.101.0-SNAPSHOT</version>
+    <version>0.102.0-SNAPSHOT</version>
 
     <licenses>
         <license>

--- a/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
@@ -67,7 +67,9 @@ public class StrimziKafkaCluster implements Startable {
         defaultKafkaConfigurationForMultiNode.put("transaction.state.log.replication.factor", String.valueOf(internalTopicReplicationFactor));
         defaultKafkaConfigurationForMultiNode.put("transaction.state.log.min.isr", String.valueOf(internalTopicReplicationFactor));
 
-        defaultKafkaConfigurationForMultiNode.putAll(additionalKafkaConfiguration);
+        if (additionalKafkaConfiguration != null) {
+            defaultKafkaConfigurationForMultiNode.putAll(additionalKafkaConfiguration);
+        }
 
         // multi-node set up
         this.brokers = IntStream
@@ -88,6 +90,15 @@ public class StrimziKafkaCluster implements Startable {
                 return kafkaContainer;
             })
             .collect(Collectors.toList());
+    }
+
+    /**
+     * Constructor of StrimziKafkaCluster without specifying additional configuration
+     *
+     * @param brokersNum number of brokers to be deployed
+     */
+    public StrimziKafkaCluster(final int brokersNum) {
+        this(brokersNum, brokersNum, null);
     }
 
     /**

--- a/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
@@ -129,7 +129,7 @@ public class StrimziKafkaCluster implements Startable {
             e.printStackTrace();
         }
 
-        Utils.waitFor("Broker node", Duration.ofSeconds(1).toMillis(), Duration.ofSeconds(30).toMillis(),
+        Utils.waitFor("Kafka brokers nodes to be connected to the ZooKeeper", Duration.ofSeconds(5).toMillis(), Duration.ofMinutes(1).toMillis(),
             () -> {
                 Container.ExecResult result;
                 try {
@@ -139,7 +139,7 @@ public class StrimziKafkaCluster implements Startable {
                     );
                     String brokers = result.getStdout();
 
-                    LOGGER.info("Stdout from zookeeper container....{}", result.getStdout());
+                    LOGGER.info("Running Kafka brokers: {}", result.getStdout());
 
                     return brokers != null && brokers.split(",").length == this.brokersNum;
                 } catch (IOException | InterruptedException e) {

--- a/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
@@ -215,6 +215,7 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
         } else if (this.hasExternalZooKeeperEnabled.test(this)) {
             kafkaConfiguration.put("zookeeper.connect", this.externalZookeeperConnect);
         } else {
+            // using internal ZooKeeper
             kafkaConfiguration.put("zookeeper.connect", "localhost:" + StrimziZookeeperContainer.ZOOKEEPER_PORT);
         }
 

--- a/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
-import java.util.function.Predicate;
 
 /**
  * StrimziKafkaContainer is a single-node instance of Kafka using the image from quay.io/strimzi/kafka with the
@@ -62,11 +61,6 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
     private boolean useKraft;
     private Function<StrimziKafkaContainer, String> bootstrapServersProvider =
         c -> String.format("PLAINTEXT://%s:%s", getContainerIpAddress(), this.kafkaExposedPort);
-
-    // predicates
-    private final Predicate<StrimziKafkaContainer> hasKraftEnabled = skc -> skc.useKraft;
-    private final Predicate<StrimziKafkaContainer> hasExternalZooKeeperEnabled = skc -> skc.externalZookeeperConnect != null;
-    private final Predicate<StrimziKafkaContainer> hasKraftOrExternalZooKeeperConfigured = skc -> skc.hasKraftEnabled.or(skc.hasExternalZooKeeperEnabled).test(skc);
 
     /**
      * Image name is specified lazily automatically in {@link #doStart()} method
@@ -106,7 +100,7 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
             throw new RuntimeException(e);
         }
         // exposing Kafka and port from the container
-        if (this.hasKraftOrExternalZooKeeperConfigured.test(this)) {
+        if (this.hasKraftOrExternalZooKeeperConfigured()) {
             super.setExposedPorts(Collections.singletonList(KAFKA_PORT));
         } else {
             // expose internal ZooKeeper internal port iff external ZooKeeper or KRaft is not specified/enabled
@@ -130,7 +124,7 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
      * @return StrimziKafkaContainer instance
      */
     public StrimziKafkaContainer waitForRunning() {
-        if (this.hasKraftEnabled.test(this)) {
+        if (this.useKraft) {
             super.waitingFor(Wait.forLogMessage(".*Transitioning from RECOVERY to RUNNING.*", 1));
         } else {
             super.waitingFor(Wait.forLogMessage(".*Recorded new controller, from now on will use broker.*", 1));
@@ -146,7 +140,7 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
         this.kafkaExposedPort = getMappedPort(KAFKA_PORT);
 
         // retrieve internal ZooKeeper internal port iff external ZooKeeper or KRaft is not specified/enabled
-        if (this.hasKraftOrExternalZooKeeperConfigured.negate().test(this)) {
+        if (!this.hasKraftOrExternalZooKeeperConfigured()) {
             this.internalZookeeperExposedPort = getMappedPort(StrimziZookeeperContainer.ZOOKEEPER_PORT);
         }
 
@@ -212,7 +206,7 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
             // explicitly say, which listener will be controller (in this case CONTROLLER)
             kafkaConfiguration.put("controller.quorum.voters", this.brokerId + "@localhost:9094");
             kafkaConfiguration.put("controller.listener.names", "CONTROLLER");
-        } else if (this.hasExternalZooKeeperEnabled.test(this)) {
+        } else if (this.externalZookeeperConnect != null) {
             LOGGER.info("Using external ZooKeeper 'zookeeper.connect={}'.", this.externalZookeeperConnect);
             kafkaConfiguration.put("zookeeper.connect", this.externalZookeeperConnect);
         } else {
@@ -249,6 +243,10 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
         );
     }
 
+    private boolean hasKraftOrExternalZooKeeperConfigured() {
+        return this.useKraft || this.externalZookeeperConnect != null;
+    }
+
     private String extractListenerName(String bootstrapServers) {
         // extract listener name from given bootstrap servers
         String[] strings = bootstrapServers.split(":");
@@ -276,7 +274,7 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
      * @return ZooKeeper connect string
      */
     public String getInternalZooKeeperConnect() {
-        if (this.hasKraftOrExternalZooKeeperConfigured.test(this)) {
+        if (this.hasKraftOrExternalZooKeeperConfigured()) {
             throw new IllegalStateException("Cannot retrieve internal ZooKeeper in case you are Using KRaft or external ZooKeeper");
         }
         return getContainerIpAddress() + ":" + this.internalZookeeperExposedPort;
@@ -310,7 +308,7 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
      * @return StrimziKafkaContainer instance
      */
     public StrimziKafkaContainer withExternalZookeeperConnect(final String externalZookeeperConnect) {
-        if (this.hasKraftEnabled.test(this)) {
+        if (this.useKraft) {
             throw new IllegalStateException("Cannot configure an external Zookeeper and use Kraft at the same time");
         }
         this.externalZookeeperConnect = externalZookeeperConnect;
@@ -374,7 +372,7 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
      */
     public StrimziKafkaContainer withServerProperties(final MountableFile serverPropertiesFile) {
         withCopyFileToContainer(serverPropertiesFile,
-                this.hasKraftEnabled.test(this) ? "/opt/kafka/config/kraft/server.properties" : "/opt/kafka/config/server.properties");
+                this.useKraft ? "/opt/kafka/config/kraft/server.properties" : "/opt/kafka/config/server.properties");
         return self();
     }
 

--- a/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
@@ -213,9 +213,11 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
             kafkaConfiguration.put("controller.quorum.voters", this.brokerId + "@localhost:9094");
             kafkaConfiguration.put("controller.listener.names", "CONTROLLER");
         } else if (this.hasExternalZooKeeperEnabled.test(this)) {
+            LOGGER.info("Using external ZooKeeper 'zookeeper.connect={}'.", this.externalZookeeperConnect);
             kafkaConfiguration.put("zookeeper.connect", this.externalZookeeperConnect);
         } else {
             // using internal ZooKeeper
+            LOGGER.info("Using internal ZooKeeper 'zookeeper.connect={}.'", "localhost:" + StrimziZookeeperContainer.ZOOKEEPER_PORT);
             kafkaConfiguration.put("zookeeper.connect", "localhost:" + StrimziZookeeperContainer.ZOOKEEPER_PORT);
         }
 

--- a/src/main/java/io/strimzi/test/container/StrimziZookeeperContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziZookeeperContainer.java
@@ -133,6 +133,6 @@ public class StrimziZookeeperContainer extends GenericContainer<StrimziZookeeper
      * @return zookeeper connect string `host:port`
      */
     public String getConnectString() {
-        return this.getHost() + ":" + this.getFirstMappedPort();
+        return this.getHost() + ":" + this.getMappedPort(ZOOKEEPER_PORT);
     }
 }

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaClusterIT.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaClusterIT.java
@@ -60,7 +60,7 @@ public class StrimziKafkaClusterIT extends AbstractIT {
         // verify that all kafka brokers are bind to zookeeper
         assertThat(brokers, notNullValue());
         // three brokers
-        assertThat(brokers, CoreMatchers.containsString("[0, 1]"));
+        assertThat(brokers, CoreMatchers.containsString("[0, 1, 2]"));
 
         LOGGER.info("Brokers are {}", systemUnderTest.getBootstrapServers());
     }
@@ -124,7 +124,7 @@ public class StrimziKafkaClusterIT extends AbstractIT {
 
     @BeforeEach
     void setUp() {
-        final int numberOfBrokers = 2;
+        final int numberOfBrokers = 3;
         numberOfReplicas = numberOfBrokers;
 
         systemUnderTest = new StrimziKafkaCluster(numberOfBrokers);

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaClusterIT.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaClusterIT.java
@@ -46,7 +46,6 @@ public class StrimziKafkaClusterIT extends AbstractIT {
     private static final Logger LOGGER = LoggerFactory.getLogger(StrimziKafkaContainerIT.class);
 
     private StrimziKafkaCluster systemUnderTest;
-    private int numberOfBrokers;
     private int numberOfReplicas;
 
     @Test
@@ -61,7 +60,7 @@ public class StrimziKafkaClusterIT extends AbstractIT {
         // verify that all kafka brokers are bind to zookeeper
         assertThat(brokers, notNullValue());
         // three brokers
-        assertThat(brokers, CoreMatchers.containsString("[0, 1, 2]"));
+        assertThat(brokers, CoreMatchers.containsString("[0, 1]"));
 
         LOGGER.info("Brokers are {}", systemUnderTest.getBootstrapServers());
     }
@@ -125,7 +124,7 @@ public class StrimziKafkaClusterIT extends AbstractIT {
 
     @BeforeEach
     void setUp() {
-        numberOfBrokers = 3;
+        final int numberOfBrokers = 2;
         numberOfReplicas = numberOfBrokers;
 
         systemUnderTest = new StrimziKafkaCluster(numberOfBrokers);

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaClusterIT.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaClusterIT.java
@@ -98,7 +98,7 @@ public class StrimziKafkaClusterIT extends AbstractIT {
 
             producer.send(new ProducerRecord<>(topicName, recordKey, recordValue)).get();
 
-            Utils.waitFor("Consumer records are present", Duration.ofSeconds(10).toMillis(), Duration.ofMinutes(1).toMillis(),
+            Utils.waitFor("Consumer records are present", Duration.ofSeconds(10).toMillis(), Duration.ofMinutes(2).toMillis(),
                 () -> {
                     ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(100));
 
@@ -109,7 +109,7 @@ public class StrimziKafkaClusterIT extends AbstractIT {
                     // verify count
                     assertThat(records.count(), is(1));
 
-                    ConsumerRecord consumerRecord = records.records(topicName).iterator().next();
+                    ConsumerRecord<String, String> consumerRecord = records.records(topicName).iterator().next();
 
                     // verify content of the record
                     assertThat(consumerRecord.topic(), is(topicName));

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaClusterIT.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaClusterIT.java
@@ -29,9 +29,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Locale;
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -126,14 +124,9 @@ public class StrimziKafkaClusterIT extends AbstractIT {
     @BeforeEach
     void setUp() {
         numberOfBrokers = 3;
-        numberOfReplicas = 2;
-        final Map<String, String> kafkaClusterConfiguration = new HashMap<>();
-        kafkaClusterConfiguration.put("zookeeper.connect", "zookeeper:2181");
+        numberOfReplicas = numberOfBrokers;
 
-        systemUnderTest = new StrimziKafkaCluster(
-            numberOfBrokers,
-            numberOfReplicas,
-            kafkaClusterConfiguration);
+        systemUnderTest = new StrimziKafkaCluster(numberOfBrokers);
         systemUnderTest.start();
     }
 

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaClusterIT.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaClusterIT.java
@@ -17,6 +17,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.hamcrest.CoreMatchers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.junit.jupiter.api.AfterEach;
@@ -59,7 +60,8 @@ public class StrimziKafkaClusterIT extends AbstractIT {
         final String brokers = result.getStdout();
         // verify that all kafka brokers are bind to zookeeper
         assertThat(brokers, notNullValue());
-        assertThat(brokers.split(",").length, is(numberOfBrokers));
+        // three brokers
+        assertThat(brokers, CoreMatchers.containsString("[0, 1, 2]"));
 
         LOGGER.info("Brokers are {}", systemUnderTest.getBootstrapServers());
     }

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaContainerIT.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaContainerIT.java
@@ -175,11 +175,15 @@ public class StrimziKafkaContainerIT extends AbstractIT {
     void testUnsupportedKafkaVersion() {
         assumeDocker();
 
-        systemUnderTest = new StrimziKafkaContainer()
-            .withKafkaVersion("2.4.0")
-            .waitForRunning();
+        try {
+            systemUnderTest = new StrimziKafkaContainer()
+                .withKafkaVersion("2.4.0")
+                .waitForRunning();
 
-        assertThrows(UnknownKafkaVersionException.class, () -> systemUnderTest.start());
+            assertThrows(UnknownKafkaVersionException.class, () -> systemUnderTest.start());
+        } finally {
+            systemUnderTest.stop();
+        }
     }
 
     @ParameterizedTest(name = "testKafkaContainerConnectFromOutsideToInternalZooKeeper-{0}")

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaKraftContainerIT.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaKraftContainerIT.java
@@ -106,25 +106,35 @@ public class StrimziKafkaKraftContainerIT extends AbstractIT {
     void testUnsupportedKRaftUsingKafkaVersion() {
         assumeDocker();
 
-        systemUnderTest = new StrimziKafkaContainer()
-            .withKafkaVersion("2.8.1")
-            .withBrokerId(1)
-            .withKraft()
-            .waitForRunning();
+        try {
+            systemUnderTest = new StrimziKafkaContainer()
+                .withKafkaVersion("2.8.1")
+                .withBrokerId(1)
+                .withKraft()
+                .waitForRunning();
 
-        assertThrows(UnsupportedKraftKafkaVersionException.class, () -> systemUnderTest.start());
+            assertThrows(UnsupportedKraftKafkaVersionException.class, () -> systemUnderTest.start());
+        } finally {
+            systemUnderTest.stop();
+        }
+
     }
 
     @Test
     void testUnsupportedKRaftUsingImageName() {
         assumeDocker();
 
-        systemUnderTest = new StrimziKafkaContainer("quay.io/strimzi-test-container/test-container:latest-kafka-2.8.1")
-            .withBrokerId(1)
-            .withKraft()
-            .waitForRunning();
+        try {
+            systemUnderTest = new StrimziKafkaContainer("quay.io/strimzi-test-container/test-container:latest-kafka-2.8.1")
+                .withBrokerId(1)
+                .withKraft()
+                .waitForRunning();
 
-        assertThrows(UnsupportedKraftKafkaVersionException.class, () -> systemUnderTest.start());
+            assertThrows(UnsupportedKraftKafkaVersionException.class, () -> systemUnderTest.start());
+        } finally {
+            systemUnderTest.stop();
+
+        }
     }
 
     private void verify() throws InterruptedException, ExecutionException, TimeoutException {

--- a/src/test/java/io/strimzi/test/container/StrimziZookeeperContainerIT.java
+++ b/src/test/java/io/strimzi/test/container/StrimziZookeeperContainerIT.java
@@ -4,10 +4,12 @@
  */
 package io.strimzi.test.container;
 
+import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.utility.MountableFile;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -66,5 +68,21 @@ public class StrimziZookeeperContainerIT extends AbstractIT {
             kafkaContainer.stop();
             systemUnderTest.stop();
         }
+    }
+
+    @ParameterizedTest(name = "testStartContainerWithZooKeeperProperties-{0}")
+    @MethodSource("retrieveKafkaVersionsFile")
+    void testStartContainerWithZooKeeperProperties(final String imageName) {
+        assumeDocker();
+
+        systemUnderTest = new StrimziZookeeperContainer(imageName)
+            .withZooKeeperPropertiesFile(MountableFile.forClasspathResource("zookeeper.properties"));
+
+        systemUnderTest.start();
+
+        String logsFromZooKeeper = systemUnderTest.getLogs();
+
+        assertThat(logsFromZooKeeper, CoreMatchers.containsString("Reading configuration from: config/zookeeper.properties"));
+        assertThat(logsFromZooKeeper, CoreMatchers.containsString("clientPortAddress is 0.0.0.0:2181"));
     }
 }

--- a/src/test/java/io/strimzi/test/container/StrimziZookeeperContainerIT.java
+++ b/src/test/java/io/strimzi/test/container/StrimziZookeeperContainerIT.java
@@ -68,14 +68,18 @@ public class StrimziZookeeperContainerIT extends AbstractIT {
     void testStartContainerWithZooKeeperProperties(final String imageName) {
         assumeDocker();
 
-        systemUnderTest = new StrimziZookeeperContainer(imageName)
-            .withZooKeeperPropertiesFile(MountableFile.forClasspathResource("zookeeper.properties"));
+        try {
+            systemUnderTest = new StrimziZookeeperContainer(imageName)
+                .withZooKeeperPropertiesFile(MountableFile.forClasspathResource("zookeeper.properties"));
+            systemUnderTest.start();
 
-        systemUnderTest.start();
+            String logsFromZooKeeper = systemUnderTest.getLogs();
 
-        String logsFromZooKeeper = systemUnderTest.getLogs();
+            assertThat(logsFromZooKeeper, CoreMatchers.containsString("Reading configuration from: config/zookeeper.properties"));
+            assertThat(logsFromZooKeeper, CoreMatchers.containsString("clientPortAddress is 0.0.0.0:2181"));
 
-        assertThat(logsFromZooKeeper, CoreMatchers.containsString("Reading configuration from: config/zookeeper.properties"));
-        assertThat(logsFromZooKeeper, CoreMatchers.containsString("clientPortAddress is 0.0.0.0:2181"));
+        } finally {
+            systemUnderTest.stop();
+        }
     }
 }

--- a/src/test/java/io/strimzi/test/container/StrimziZookeeperContainerIT.java
+++ b/src/test/java/io/strimzi/test/container/StrimziZookeeperContainerIT.java
@@ -11,9 +11,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.utility.MountableFile;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -48,12 +45,8 @@ public class StrimziZookeeperContainerIT extends AbstractIT {
             systemUnderTest = new StrimziZookeeperContainer(imageName);
             systemUnderTest.start();
 
-            Map<String, String> config = new HashMap<>();
-            config.put("zookeeper.connect", "zookeeper:2181");
-
             kafkaContainer = new StrimziKafkaContainer()
                 .withBrokerId(1)
-                .withKafkaConfigurationMap(config)
                 .withExternalZookeeperConnect("zookeeper:" + StrimziZookeeperContainer.ZOOKEEPER_PORT);
 
             kafkaContainer.start();

--- a/src/test/resources/zookeeper.properties
+++ b/src/test/resources/zookeeper.properties
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# the directory where the snapshot is stored.
+dataDir=/tmp/zookeeper
+# the port at which the clients will connect
+clientPort=2181
+maxClientCnxns=100
+# Disable the adminserver by default to avoid port conflicts.
+# Set the port to something non-conflicting if choosing to enable this
+admin.enableServer=false
+# admin.serverPort=8080


### PR DESCRIPTION
…onents (ZkClient etc.)

**StrimziKafkaContainer**

Currently, in StrimziKafkaContainer we are not able to connect to internal ZooKeeper, which is running inside the same container as Kafka. This PR exposes such ZooKeeper and adds a few test cases to proper check implementation.

```java
// start container with implicit internal ZooKeeper
systemUnderTest = new StrimziKafkaContainer()
     .waitForRunning();
systemUnderTest.start();

// Creates a socket address from a hostname and a port number
final String[] hostNameWithPort = systemUnderTest.getInternalZooKeeperConnect().split(":");

// connect to the ZooKeeper from external Socket
SocketAddress socketAddress = new InetSocketAddress(hostNameWithPort[0], Integer.parseInt(hostNameWithPort[1]));
```

Moreover adds a few helpful stuff such as:

**StrimziKafkaCluster**
1. Constructor only specified number of brokers 
2. Better logs description

**StrimziZooKeeperCluster**
1. adds an option to specify the custom ZooKeeper properties file 
 
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>