### PR TITLE
Avoid setting container config on doStart method

### DIFF
--- a/src/main/java/io/strimzi/test/container/StrimziZookeeperContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziZookeeperContainer.java
@@ -63,13 +63,6 @@ public class StrimziZookeeperContainer extends GenericContainer<StrimziZookeeper
     private StrimziZookeeperContainer(CompletableFuture<String> imageName) {
         super(imageName);
         this.imageNameProvider = imageName;
-    }
-
-    @Override
-    protected void doStart() {
-        if (!imageNameProvider.isDone()) {
-            imageNameProvider.complete(KafkaVersionService.strimziTestContainerImageName(kafkaVersion));
-        }
         // we need this shared network in case we deploy StrimziKafkaCluster, which consist `StrimziZookeeperContainer`
         // instance and by default each container has its own network
         super.setNetwork(Network.SHARED);
@@ -80,6 +73,13 @@ public class StrimziZookeeperContainer extends GenericContainer<StrimziZookeeper
         super.addEnv("ZOOKEEPER_CLIENT_PORT", String.valueOf(ZOOKEEPER_PORT));
         // env for readiness
         super.addEnv("ZOO_4LW_COMMANDS_WHITELIST", "ruok");
+    }
+
+    @Override
+    protected void doStart() {
+        if (!imageNameProvider.isDone()) {
+            imageNameProvider.complete(KafkaVersionService.strimziTestContainerImageName(kafkaVersion));
+        }
         // we need it for the startZookeeper(); and startKafka(); to run container before...
         withCommand("sh", "-c", "while [ ! -f " + STARTER_SCRIPT + " ]; do sleep 0.1; done; " + STARTER_SCRIPT);
         super.doStart();

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaContainerIT.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaContainerIT.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.Container;
+import org.testcontainers.containers.Network;
 import org.testcontainers.utility.MountableFile;
 
 import java.io.IOException;
@@ -168,6 +169,25 @@ public class StrimziKafkaContainerIT extends AbstractIT {
                 + systemUnderTest.getContainerIpAddress() + ":" + systemUnderTest.getMappedPort(9092)));
 
         assertThat(systemUnderTest.getDockerImageName(), is(imageName));
+        systemUnderTest.stop();
+    }
+
+    @Test
+    void testStartContainerWithCustomNetwork() {
+        assumeDocker();
+
+        Network network = Network.newNetwork();
+
+        systemUnderTest = new StrimziKafkaContainer()
+                .withNetwork(network)
+                .waitForRunning();
+
+        systemUnderTest.start();
+
+        assertThat(systemUnderTest.getBootstrapServers(), is("PLAINTEXT://"
+                + systemUnderTest.getContainerIpAddress() + ":" + systemUnderTest.getMappedPort(9092)));
+
+        assertThat(systemUnderTest.getNetwork().getId(), is(network.getId()));
         systemUnderTest.stop();
     }
 


### PR DESCRIPTION
Otherwise, the configuration for custom container network is overridden by the doStart method.

Signed-off-by: Ozan Gunalp <ozangunalp@gmail.com>