### PR TITLE
Remove compile dependency on kafka-clients

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,7 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <version>${kafka.version}</version>
+            <scope>test</scope>
         </dependency>
 
 


### PR DESCRIPTION
The `kafka-clients` 3+ dependency is currently declared with `compile` scope, which makes the library harder to integrate in code bases when using a `kafka-clients` 2+ (code base where the migration to `kafka-client`` 3+ is not easily doable).

The dependency is only used to generate an UUID in the `StrimziKafkaContainer` class using the Kafka client's `org.apache.kafka.common.Uuid`, in order to apply a specific filter to ignore 2 specific Kafka UUIDs (metadata topic uuid & zero uuid) and to encode the UUID in base64.

The constraints to have a `compile` dependency on the `kafka-clients` seems very high compared to the benefits.