### PR TITLE
Shell quoting for Kafka config

### DIFF
--- a/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
@@ -271,14 +271,14 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
         return strings[0];
     }
 
-    private String writeOverrideString(Map<String, String> kafkaConfigurationMap) {
+    static String writeOverrideString(Map<String, String> kafkaConfigurationMap) {
         StringBuilder kafkaConfiguration = new StringBuilder();
         kafkaConfigurationMap.forEach((configName, configValue) ->
                 kafkaConfiguration
                         .append(" --override ")
-                        .append(configName)
+                        .append('\'').append(configName.replace("'", "'\"'\"'"))
                         .append("=")
-                        .append(configValue));
+                        .append(configValue.replace("'", "'\"'\"'")).append('\''));
         return kafkaConfiguration.toString();
     }
 

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaContainerTest.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaContainerTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.test.container;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class StrimziKafkaContainerTest {
+
+    @Test
+    public void testWriteOverrideString() {
+        Map<String, String> map = new HashMap<>();
+        map.put("foo", "bar");
+        assertEquals(" --override 'foo=bar'", StrimziKafkaContainer.writeOverrideString(map));
+        map.put("foo", "bar with spaces");
+        assertEquals(" --override 'foo=bar with spaces'", StrimziKafkaContainer.writeOverrideString(map));
+        map.put("foo", "bar with \"double quotes\"");
+        assertEquals(" --override 'foo=bar with \"double quotes\"'", StrimziKafkaContainer.writeOverrideString(map));
+        map.put("foo", "bar with 'single quotes'");
+        assertEquals(" --override 'foo=bar with '\"'\"'single quotes'\"'\"''", StrimziKafkaContainer.writeOverrideString(map));
+
+    }
+
+}


### PR DESCRIPTION
I found (while trying to configure a `ssl.keystore.password` that happened to contain spaces) that there was not quoting of the map values passed to `StrimziKafkaContainer.withKafkaConfigurationMap`: They were open to interpretation by the shell. This PR quotes them using single quotes. 