### PR TITLE
Fix #40: Update test containers version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,10 +89,10 @@
         <maven.compiler.source>1.8</maven.compiler.source>
 
         <!-- DEPENDENCY CODE VERSIONS       -->
-        <test-containers.version>1.15.2</test-containers.version>
+        <test-containers.version>1.17.2</test-containers.version>
         <spotbugs.version>4.0.3</spotbugs.version>
         <log4j.version>2.17.1</log4j.version>
-        <docker-java.version>3.2.7</docker-java.version>
+        <docker-java.version>3.2.13</docker-java.version>
         <kafka.version>3.0.0</kafka.version>
         <slf4j.version>1.7.32</slf4j.version>
         <fasterxml.jackson-core.version>2.11.3</fasterxml.jackson-core.version>

--- a/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
@@ -64,7 +64,7 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
     private int brokerId;
     private String kafkaVersion;
     private boolean useKraft;
-    private Function<StrimziKafkaContainer, String> bootstrapServersProvider = c -> String.format("PLAINTEXT://%s:%s", getContainerIpAddress(), this.kafkaExposedPort);
+    private Function<StrimziKafkaContainer, String> bootstrapServersProvider = c -> String.format("PLAINTEXT://%s:%s", getHost(), this.kafkaExposedPort);
 
     /**
      * Image name is specified lazily automatically in {@link #doStart()} method
@@ -310,7 +310,7 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
         if (this.hasKraftOrExternalZooKeeperConfigured()) {
             throw new IllegalStateException("Cannot retrieve internal ZooKeeper in case you are Using KRaft or external ZooKeeper");
         }
-        return getContainerIpAddress() + ":" + this.internalZookeeperExposedPort;
+        return getHost() + ":" + this.internalZookeeperExposedPort;
     }
 
     /**

--- a/src/test/java/io/strimzi/test/container/StrimziZookeeperContainerIT.java
+++ b/src/test/java/io/strimzi/test/container/StrimziZookeeperContainerIT.java
@@ -34,7 +34,9 @@ public class StrimziZookeeperContainerIT extends AbstractIT {
             assertThat(zookeeperLogs, notNullValue());
             assertThat(zookeeperLogs, containsString("Created server"));
         } finally {
-            systemUnderTest.stop();
+            if (systemUnderTest != null) {
+                systemUnderTest.stop();
+            }
         }
     }
 
@@ -58,8 +60,12 @@ public class StrimziZookeeperContainerIT extends AbstractIT {
             // kafka established connection to external zookeeper
             assertThat(kafkaLogs, containsString("Session establishment complete on server zookeeper"));
         } finally {
-            kafkaContainer.stop();
-            systemUnderTest.stop();
+            if (kafkaContainer != null) {
+                kafkaContainer.stop();
+            }
+            if (systemUnderTest != null) {
+                systemUnderTest.stop();
+            }
         }
     }
 
@@ -79,7 +85,9 @@ public class StrimziZookeeperContainerIT extends AbstractIT {
             assertThat(logsFromZooKeeper, CoreMatchers.containsString("clientPortAddress is 0.0.0.0:2181"));
 
         } finally {
-            systemUnderTest.stop();
+            if (systemUnderTest != null) {
+                systemUnderTest.stop();
+            }
         }
     }
 }


### PR DESCRIPTION
* Update docker java version, since it's a transitive dep of testcontainers
* `getContainerIpAddress()` got deprecated, so use `getHost`()
* `systemUnderTest` can be null if the instantiation failed, so add a null check to avoid hiding the original exception.