### PR TITLE
Add proxy container configuration

### DIFF
--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -87,7 +87,10 @@
         <!-- code quality -->
         <module name="MethodLength"/>
         <module name="ParameterNumber"/>
-        <module name="ClassDataAbstractionCoupling"/>
+        <module name="ClassDataAbstractionCoupling">
+            <!-- default is 7 -->
+            <property name="max" value="10"/>
+        </module>
         <module name="BooleanExpressionComplexity"/>
         <module name="ClassFanOutComplexity"/>
         <module name="CyclomaticComplexity">

--- a/README.md
+++ b/README.md
@@ -185,6 +185,26 @@ StrimziKafkaContainer strimziKafkaContainer = new StrimziKafkaContainer()
 strimziKafkaContainer.start();
 ```
 
+#### ix) (Optional) Specify a proxy container to simulate network conditions (i.e. connection cut, latency).
+
+This container allows to create a TCP proxy between test code and Kafka broker.
+
+Every Kafka broker request will pass through the proxy where you can simulate network conditions (i.e. connection cut, latency).
+
+```java
+ToxiproxyContainer proxyContainer = new ToxiproxyContainer(
+        DockerImageName.parse("ghcr.io/shopify/toxiproxy:2.4.0")
+            .asCompatibleSubstituteFor("shopify/toxiproxy"));
+
+StrimziKafkaContainer strimziKafkaContainer = new StrimziKafkaContainer()
+        .withProxyContainer(proxyContainer)
+        .waitForRunning();
+
+systemUnderTest.start();
+
+strimziKafkaContainer.getProxy().setConnectionCut(true);
+```
+
 ### Additional tips
 
 1. In case you are using `Azure pipelines` Ryuk needs to be turned off, since Azure does not allow starting privileged containers.

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>io.strimzi</groupId>
     <artifactId>strimzi-test-container</artifactId>
     <packaging>jar</packaging>
-    <version>0.101.0-SNAPSHOT</version>
+    <version>0.103.0-SNAPSHOT</version>
 
     <licenses>
         <license>
@@ -133,6 +133,11 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
+            <version>${test-containers.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>toxiproxy</artifactId>
             <version>${test-containers.version}</version>
         </dependency>
         <dependency>

--- a/src/main/java/io/strimzi/test/container/KafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/KafkaContainer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.test.container;
+
+import org.testcontainers.lifecycle.Startable;
+
+public interface KafkaContainer extends Startable {
+    /**
+     * Check if the cluster is running in KRaft mode or it is using an external ZK.
+     *
+     * @return true only in KRaft mode or when using an external ZK
+     */
+    boolean hasKraftOrExternalZooKeeperConfigured();
+
+    /**
+     * Get the internal ZooKeeper connect string.
+     *
+     * @return ZooKeeper connect string
+     *
+     * @throws IllegalStateException
+     *      if in KRaft mode or using an external ZooKeeper
+     */
+    String getInternalZooKeeperConnect();
+
+    /**
+     * Get the Kafka cluster bootstrap servers.
+     *
+     * @return bootstrap servers
+     */
+    String getBootstrapServers();
+}

--- a/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
@@ -8,7 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.Network;
-import org.testcontainers.lifecycle.Startable;
+import org.testcontainers.containers.ToxiproxyContainer;
 import org.testcontainers.lifecycle.Startables;
 
 import java.io.IOException;
@@ -28,7 +28,7 @@ import java.util.stream.Stream;
  * It perfectly fits for integration/system testing. We always deploy one zookeeper with a specified number of Kafka instances,
  * running as a separate container inside Docker. The additional configuration for Kafka brokers can be passed to the constructor.
  */
-public class StrimziKafkaCluster implements Startable {
+public class StrimziKafkaCluster implements KafkaContainer {
 
     // class attributes
     private static final Logger LOGGER = LoggerFactory.getLogger(StrimziKafkaCluster.class);
@@ -37,17 +37,22 @@ public class StrimziKafkaCluster implements Startable {
     private final int brokersNum;
     private final Network network;
     private final StrimziZookeeperContainer zookeeper;
-    private final Collection<StrimziKafkaContainer> brokers;
+    private final Collection<KafkaContainer> brokers;
 
     /**
      * Constructor for @StrimziKafkaCluster class, which allows you to specify number of brokers @see{brokersNum},
      * replication factor of internal topics @see{internalTopicReplicationFactor} and map of additional Kafka
      * configuration @see{additionalKafkaConfiguration}.
+     *
      * @param brokersNum number of brokers
      * @param internalTopicReplicationFactor internal topics
      * @param additionalKafkaConfiguration additional Kafka configuration
+     * @param proxyContainer Proxy container instance
      */
-    public StrimziKafkaCluster(final int brokersNum, final int internalTopicReplicationFactor, final Map<String, String> additionalKafkaConfiguration) {
+    public StrimziKafkaCluster(final int brokersNum,
+                               final int internalTopicReplicationFactor,
+                               final Map<String, String> additionalKafkaConfiguration,
+                               final ToxiproxyContainer proxyContainer) {
         if (brokersNum < 0) {
             throw new IllegalArgumentException("brokersNum '" + brokersNum + "' must be greater than 0");
         }
@@ -71,17 +76,22 @@ public class StrimziKafkaCluster implements Startable {
             defaultKafkaConfigurationForMultiNode.putAll(additionalKafkaConfiguration);
         }
 
+        if (proxyContainer != null) {
+            proxyContainer.setNetwork(this.network);
+        }
+
         // multi-node set up
         this.brokers = IntStream
             .range(0, this.brokersNum)
             .mapToObj(brokerId -> {
                 LOGGER.info("Starting broker with id {}", brokerId);
                 // adding broker id for each kafka container
-                StrimziKafkaContainer kafkaContainer = new StrimziKafkaContainer()
+                KafkaContainer kafkaContainer = new StrimziKafkaContainer()
                     .withBrokerId(brokerId)
                     .withKafkaConfigurationMap(defaultKafkaConfigurationForMultiNode)
                     .withExternalZookeeperConnect("zookeeper:" + StrimziZookeeperContainer.ZOOKEEPER_PORT)
                     .withNetwork(this.network)
+                    .withProxyContainer(proxyContainer)
                     .withNetworkAliases("broker-" + brokerId)
                     .dependsOn(this.zookeeper);
 
@@ -98,30 +108,51 @@ public class StrimziKafkaCluster implements Startable {
      * @param brokersNum number of brokers to be deployed
      */
     public StrimziKafkaCluster(final int brokersNum) {
-        this(brokersNum, brokersNum, null);
+        this(brokersNum, brokersNum, null, null);
+    }
+
+    /**
+     * Constructor of StrimziKafkaCluster with proxy container
+     *
+     * @param brokersNum number of brokers to be deployed
+     * @param proxyContainer Proxy container instance
+     */
+    public StrimziKafkaCluster(final int brokersNum, final ToxiproxyContainer proxyContainer) {
+        this(brokersNum, brokersNum, null, proxyContainer);
     }
 
     /**
      * Get collection of Strimzi kafka containers
      * @return collection of Strimzi kafka containers
      */
-    public Collection<StrimziKafkaContainer> getBrokers() {
+    public Collection<KafkaContainer> getBrokers() {
         return this.brokers;
     }
 
-    /**
-     * Get bootstrap servers as a string, which can be inserted inside Kafka config
-     * @return bootstrap servers
-     */
+    @Override
+    public boolean hasKraftOrExternalZooKeeperConfigured() {
+        KafkaContainer broker0 = brokers.iterator().next();
+        return broker0.hasKraftOrExternalZooKeeperConfigured() ? true : false;
+    }
+
+    @Override
+    public String getInternalZooKeeperConnect() {
+        if (hasKraftOrExternalZooKeeperConfigured()) {
+            throw new IllegalStateException("Connect string is not available when using KRaft or external ZooKeeper");
+        }
+        return getZookeeper() != null ? getZookeeper().getConnectString() : null;
+    }
+
+    @Override
     public String getBootstrapServers() {
         return brokers.stream()
-            .map(StrimziKafkaContainer::getBootstrapServers)
+            .map(KafkaContainer::getBootstrapServers)
             .collect(Collectors.joining(","));
     }
 
     @Override
     public void start() {
-        Stream<? extends Startable> startables = this.brokers.stream();
+        Stream<KafkaContainer> startables = this.brokers.stream();
         try {
             Startables.deepStart(startables).get(60, TimeUnit.SECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
@@ -158,7 +189,7 @@ public class StrimziKafkaCluster implements Startable {
         // stop all kafka containers in parallel
         this.brokers.stream()
             .parallel()
-            .forEach(StrimziKafkaContainer::stop);
+            .forEach(KafkaContainer::stop);
     }
 
     /**

--- a/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
@@ -10,6 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
+import org.testcontainers.containers.ToxiproxyContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.containers.wait.strategy.WaitStrategy;
 import org.testcontainers.images.builder.Transferable;
@@ -36,7 +37,7 @@ import java.util.function.Function;
  * The additional configuration for Kafka broker can be injected via constructor. This container is a good fit for
  * integration testing but for more hardcore testing we suggest using @StrimziKafkaCluster.
  */
-public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContainer> {
+public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContainer> implements KafkaContainer {
 
     // class attributes
     private static final Logger LOGGER = LoggerFactory.getLogger(StrimziKafkaContainer.class);
@@ -65,6 +66,10 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
     private String kafkaVersion;
     private boolean useKraft;
     private Function<StrimziKafkaContainer, String> bootstrapServersProvider = c -> String.format("PLAINTEXT://%s:%s", getHost(), this.kafkaExposedPort);
+
+    // proxy attributes
+    private ToxiproxyContainer proxyContainer;
+    private ToxiproxyContainer.ContainerProxy proxy;
 
     /**
      * Image name is specified lazily automatically in {@link #doStart()} method
@@ -98,6 +103,9 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
 
     @Override
     protected void doStart() {
+        if (proxyContainer != null && !proxyContainer.isRunning()) {
+            proxyContainer.start();
+        }
         if (!this.imageNameProvider.isDone()) {
             this.imageNameProvider.complete(KafkaVersionService.strimziTestContainerImageName(this.kafkaVersion));
         }
@@ -117,6 +125,14 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
         // we need it for the startZookeeper(); and startKafka(); to run container before...
         super.setCommand("sh", "-c", runStarterScript());
         super.doStart();
+    }
+
+    @Override
+    public void stop() {
+        if (proxyContainer != null && proxyContainer.isRunning()) {
+            proxyContainer.stop();
+        }
+        super.stop();
     }
 
     /**
@@ -257,7 +273,8 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
         );
     }
 
-    private boolean hasKraftOrExternalZooKeeperConfigured() {
+    @Override
+    public boolean hasKraftOrExternalZooKeeperConfigured() {
         return this.useKraft || this.externalZookeeperConnect != null;
     }
 
@@ -301,24 +318,21 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
         return Base64.getUrlEncoder().withoutPadding().encodeToString(uuidBytesArray);
     }
 
-    /**
-     * Get internal ZooKeeper connect string, which is running in the same container as Kafka
-     *
-     * @return ZooKeeper connect string
-     */
+    @Override
     public String getInternalZooKeeperConnect() {
         if (this.hasKraftOrExternalZooKeeperConfigured()) {
-            throw new IllegalStateException("Cannot retrieve internal ZooKeeper in case you are Using KRaft or external ZooKeeper");
+            throw new IllegalStateException("Connect string is not available when using KRaft or external ZooKeeper");
         }
         return getHost() + ":" + this.internalZookeeperExposedPort;
     }
 
-    /**
-     * Get bootstrap servers of @code{StrimziKafkaContainer} instance
-     *
-     * @return bootstrap servers
-     */
+    @Override
     public String getBootstrapServers() {
+        if (proxyContainer != null && proxyContainer.isRunning()) {
+            return String.format("PLAINTEXT://%s:%d",
+                    getProxy().getContainerIpAddress(),
+                    getProxy().getProxyPort());
+        }
         return bootstrapServersProvider.apply(this);
     }
 
@@ -383,7 +397,6 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
         return self();
     }
 
-
     /**
      * Fluent method, which sets fixed exposed port.
      *
@@ -419,5 +432,39 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
     public StrimziKafkaContainer withBootstrapServers(final Function<StrimziKafkaContainer, String> provider) {
         this.bootstrapServersProvider = provider;
         return self();
+    }
+
+    /**
+     * Fluent method, which sets a proxy container.
+     * This container allows to create a TCP proxy between test code and Kafka broker.
+     *
+     * Every Kafka broker request will pass through the proxy where you can simulate
+     * network conditions (i.e. connection cut, latency).
+     *
+     * @param proxyContainer Proxy container instance
+     * @return StrimziKafkaContainer instance
+     */
+    public StrimziKafkaContainer withProxyContainer(final ToxiproxyContainer proxyContainer) {
+        if (proxyContainer != null) {
+            this.proxyContainer = proxyContainer;
+            proxyContainer.setNetwork(Network.SHARED);
+            proxyContainer.setNetworkAliases(Collections.singletonList("toxiproxy"));
+        }
+        return self();
+    }
+
+    /**
+     * Returns the proxy for this Kafka broker if configured.
+     *
+     * @return container proxy or null
+     */
+    public synchronized ToxiproxyContainer.ContainerProxy getProxy() {
+        if (proxyContainer == null) {
+            throw new IllegalStateException("The proxy container has not been configured");
+        }
+        if (proxy == null) {
+            proxy = proxyContainer.getProxy(this, KAFKA_PORT);
+        }
+        return proxy;
     }
 }

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaClusterIT.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaClusterIT.java
@@ -4,6 +4,9 @@
  */
 package io.strimzi.test.container;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
@@ -24,6 +27,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.Container;
+import org.testcontainers.containers.ToxiproxyContainer;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 
 import java.io.IOException;
@@ -39,6 +43,7 @@ import java.util.concurrent.TimeoutException;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import org.testcontainers.utility.DockerImageName;
 
 @SuppressWarnings("ClassFanOutComplexity")
 public class StrimziKafkaClusterIT extends AbstractIT {
@@ -120,6 +125,28 @@ public class StrimziKafkaClusterIT extends AbstractIT {
                     return true;
                 });
         }
+    }
+
+    @Test
+    void testStartClusterWithProxyContainer() {
+        ToxiproxyContainer proxyContainer = new ToxiproxyContainer(
+                DockerImageName.parse("ghcr.io/shopify/toxiproxy:2.4.0")
+                        .asCompatibleSubstituteFor("shopify/toxiproxy"));
+
+        StrimziKafkaCluster kafkaCluster = new StrimziKafkaCluster(3, proxyContainer);
+        kafkaCluster.start();
+
+        List<String> bootstrapUrls = new ArrayList<>();
+        for (KafkaContainer kafkaContainer : kafkaCluster.getBrokers()) {
+            ToxiproxyContainer.ContainerProxy proxy = ((StrimziKafkaContainer) kafkaContainer).getProxy();
+            assertThat(proxy, notNullValue());
+            bootstrapUrls.add(kafkaContainer.getBootstrapServers());
+        }
+
+        assertThat(kafkaCluster.getBootstrapServers(),
+                is(bootstrapUrls.stream().collect(Collectors.joining(","))));
+
+        kafkaCluster.stop();
     }
 
     @BeforeEach


### PR DESCRIPTION
A proxy container (i.e. Toxiproxy) can be optionally configured.
This container allows to create a TCP proxy between test code and Kafka broker.

Every Kafka broker request will pass through the proxy where you can simulate
network conditions (i.e. connection cut, latency). For example, you can create
a network partition when running a multi-node cluster.

This commit also adds a common super-interface for containers.

Signed-off-by: Federico Valeri <fedevaleri@gmail.com>