### PR TITLE
[MO] - Kafka cluster number of brokers fixed + unit tests

### DIFF
--- a/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
@@ -56,7 +56,7 @@ public class StrimziKafkaCluster implements KafkaContainer {
                                final int internalTopicReplicationFactor,
                                final Map<String, String> additionalKafkaConfiguration,
                                final ToxiproxyContainer proxyContainer) {
-        if (brokersNum < 0) {
+        if (brokersNum <= 0) {
             throw new IllegalArgumentException("brokersNum '" + brokersNum + "' must be greater than 0");
         }
         if (internalTopicReplicationFactor < 0 || internalTopicReplicationFactor > brokersNum) {

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaClusterTest.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaClusterTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
 package io.strimzi.test.container;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaClusterTest.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaClusterTest.java
@@ -1,0 +1,27 @@
+package io.strimzi.test.container;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class StrimziKafkaClusterTest {
+
+    @Test
+    void testKafkaClusterNegativeOrZeroNumberOfNodes() {
+        assertThrows(IllegalArgumentException.class, () -> new StrimziKafkaCluster(
+            0, 1, null, null));
+        assertThrows(IllegalArgumentException.class, () -> new StrimziKafkaCluster(
+            -1, 1, null, null));
+    }
+
+    @Test
+    void testKafkaClusterPossibleNumberOfNodes() {
+        assertDoesNotThrow(() -> new StrimziKafkaCluster(
+            1, 1, null, null));
+        assertDoesNotThrow(() -> new StrimziKafkaCluster(
+            3, 3, null, null));
+        assertDoesNotThrow(() -> new StrimziKafkaCluster(
+            10, 3, null, null));
+    }
+}


### PR DESCRIPTION
This PR fixes the problem when one will hypothetically want to create a Kafka cluster with zero nodes. Currently, it won't fail, therefore I modified the condition to do so. Plus I have added a few unit tests to check that behaviour.

Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>