### PR TITLE
Update Jackson to address CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,8 +95,8 @@
         <docker-java.version>3.2.13</docker-java.version>
         <kafka.version>3.2.3</kafka.version>
         <slf4j.version>1.7.32</slf4j.version>
-        <fasterxml.jackson-core.version>2.12.6</fasterxml.jackson-core.version>
-        <fasterxml.jackson-databind.version>2.12.6.1</fasterxml.jackson-databind.version>
+        <fasterxml.jackson-core.version>2.13.4</fasterxml.jackson-core.version>
+        <fasterxml.jackson-databind.version>2.13.4.1</fasterxml.jackson-databind.version>
 
         <!-- DEPENDENCY TEST VERSIONS      -->
         <jupiter.version>5.9.1</jupiter.version>


### PR DESCRIPTION
This PR updates Jackson to 2.13.4 / 2.13.4.1 to address thelatest CVEs.