### PR TITLE
Update to the newest Kafka + some minor changes

### DIFF
--- a/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
@@ -116,7 +116,7 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
             this.imageNameProvider.complete(KafkaVersionService.strimziTestContainerImageName(this.kafkaVersion));
         }
         try {
-            if (this.useKraft && ((this.kafkaVersion != null && this.kafkaVersion.equals("2.8.2")) || this.imageNameProvider.get().contains("2.8.2"))) {
+            if (this.useKraft && ((this.kafkaVersion != null && this.kafkaVersion.startsWith("2.")) || this.imageNameProvider.get().contains("2."))) {
                 throw new UnsupportedKraftKafkaVersionException("Specified Kafka version " + this.kafkaVersion + " is not supported in KRaft mode.");
             }
         } catch (InterruptedException | ExecutionException e) {

--- a/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
@@ -116,7 +116,7 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
             this.imageNameProvider.complete(KafkaVersionService.strimziTestContainerImageName(this.kafkaVersion));
         }
         try {
-            if (this.useKraft && ((this.kafkaVersion != null && this.kafkaVersion.startsWith("2.")) || this.imageNameProvider.get().contains("2."))) {
+            if (this.useKraft && ((this.kafkaVersion != null && this.kafkaVersion.startsWith("2.")) || this.imageNameProvider.get().contains("2.8.2"))) {
                 throw new UnsupportedKraftKafkaVersionException("Specified Kafka version " + this.kafkaVersion + " is not supported in KRaft mode.");
             }
         } catch (InterruptedException | ExecutionException e) {

--- a/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
@@ -116,7 +116,7 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
             this.imageNameProvider.complete(KafkaVersionService.strimziTestContainerImageName(this.kafkaVersion));
         }
         try {
-            if (this.useKraft && ((this.kafkaVersion != null && this.kafkaVersion.equals("2.8.1")) || this.imageNameProvider.get().contains("2.8.1"))) {
+            if (this.useKraft && ((this.kafkaVersion != null && this.kafkaVersion.equals("2.8.2")) || this.imageNameProvider.get().contains("2.8.2"))) {
                 throw new UnsupportedKraftKafkaVersionException("Specified Kafka version " + this.kafkaVersion + " is not supported in KRaft mode.");
             }
         } catch (InterruptedException | ExecutionException e) {
@@ -163,7 +163,7 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
         if (this.useKraft) {
             super.waitingFor(Wait.forLogMessage(".*Transitioning from RECOVERY to RUNNING.*", 1));
         } else {
-            super.waitingFor(Wait.forLogMessage(".*Recorded new controller, from now on will use broker.*", 1));
+            super.waitingFor(Wait.forLogMessage(".*Recorded new controller, from now on will use [node|broker].*", 1));
         }
         return this;
     }

--- a/src/main/resources/kafka_versions.json
+++ b/src/main/resources/kafka_versions.json
@@ -1,10 +1,10 @@
 {
   "kafkaVersions": {
-    "2.8.1": "quay.io/strimzi-test-container/test-container:latest-kafka-2.8.1",
-    "3.0.1": "quay.io/strimzi-test-container/test-container:latest-kafka-3.0.1",
-    "3.1.0": "quay.io/strimzi-test-container/test-container:latest-kafka-3.1.0",
-    "3.1.1": "quay.io/strimzi-test-container/test-container:latest-kafka-3.1.1",
-    "3.2.0": "quay.io/strimzi-test-container/test-container:latest-kafka-3.2.0",
-    "3.2.1": "quay.io/strimzi-test-container/test-container:latest-kafka-3.2.1"
+    "2.8.2": "quay.io/strimzi-test-container/test-container:latest-kafka-2.8.2",
+    "3.0.2": "quay.io/strimzi-test-container/test-container:latest-kafka-3.0.2",
+    "3.1.2": "quay.io/strimzi-test-container/test-container:latest-kafka-3.1.2",
+    "3.2.3": "quay.io/strimzi-test-container/test-container:latest-kafka-3.2.3",
+    "3.3.2": "quay.io/strimzi-test-container/test-container:latest-kafka-3.3.2",
+    "3.4.0": "quay.io/strimzi-test-container/test-container:latest-kafka-3.4.0"
   }
 }

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaKraftContainerIT.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaKraftContainerIT.java
@@ -110,7 +110,7 @@ public class StrimziKafkaKraftContainerIT extends AbstractIT {
 
         try {
             systemUnderTest = new StrimziKafkaContainer()
-                .withKafkaVersion("2.8.1")
+                .withKafkaVersion("2.8.2")
                 .withBrokerId(1)
                 .withKraft()
                 .waitForRunning();
@@ -127,7 +127,7 @@ public class StrimziKafkaKraftContainerIT extends AbstractIT {
         assumeDocker();
 
         try {
-            systemUnderTest = new StrimziKafkaContainer("quay.io/strimzi-test-container/test-container:latest-kafka-2.8.1")
+            systemUnderTest = new StrimziKafkaContainer("quay.io/strimzi-test-container/test-container:latest-kafka-2.8.2")
                 .withBrokerId(1)
                 .withKraft()
                 .waitForRunning();


### PR DESCRIPTION
This PR adds support for Kafka versions, which were introduced (https://github.com/strimzi/test-container-images/pull/14). Also, it adds some minor changes (i.e., changing regex for waiting until the cluster is ready).