### PR TITLE
Add Kafka 3.4.1 and 3.5.0 + fix tests

### DIFF
--- a/src/main/resources/kafka_versions.json
+++ b/src/main/resources/kafka_versions.json
@@ -5,6 +5,7 @@
     "3.1.2": "quay.io/strimzi-test-container/test-container:latest-kafka-3.1.2",
     "3.2.3": "quay.io/strimzi-test-container/test-container:latest-kafka-3.2.3",
     "3.3.2": "quay.io/strimzi-test-container/test-container:latest-kafka-3.3.2",
-    "3.4.0": "quay.io/strimzi-test-container/test-container:latest-kafka-3.4.0"
+    "3.4.1": "quay.io/strimzi-test-container/test-container:latest-kafka-3.4.1",
+    "3.5.0": "quay.io/strimzi-test-container/test-container:latest-kafka-3.5.0"
   }
 }

--- a/src/test/java/io/strimzi/test/container/AbstractIT.java
+++ b/src/test/java/io/strimzi/test/container/AbstractIT.java
@@ -34,7 +34,7 @@ public class AbstractIT {
 
         for (Iterator<Map.Entry<String, JsonNode>> iter = rootNode.get("kafkaVersions").fields(); iter.hasNext(); ) {
             final Map.Entry<String, JsonNode> fields = iter.next();
-            parameters.add(Arguments.of(fields.getValue().asText()));
+            parameters.add(Arguments.of(fields.getValue().asText(), fields.getKey()));
         }
         return parameters.stream();
     }
@@ -45,5 +45,9 @@ public class AbstractIT {
 
     protected void supportsKraftMode(final String imageName) {
         Assumptions.assumeTrue(!imageName.contains("-kafka-2."));
+    }
+
+    protected boolean isLessThanKafka350(final String kafkaVersion) {
+        return KafkaVersionService.KafkaVersion.compareVersions(kafkaVersion, "3.5.0") == -1;
     }
 }

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaKraftContainerIT.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaKraftContainerIT.java
@@ -43,7 +43,7 @@ public class StrimziKafkaKraftContainerIT extends AbstractIT {
 
     @ParameterizedTest(name = "testStartContainerWithEmptyConfiguration-{0}")
     @MethodSource("retrieveKafkaVersionsFile")
-    void testStartContainerWithEmptyConfiguration(final String imageName) throws ExecutionException, InterruptedException, TimeoutException {
+    void testStartContainerWithEmptyConfiguration(final String imageName, final String kafkaVersion) throws ExecutionException, InterruptedException, TimeoutException {
         assumeDocker();
         supportsKraftMode(imageName);
 
@@ -57,7 +57,12 @@ public class StrimziKafkaKraftContainerIT extends AbstractIT {
             assertThat(systemUnderTest.getClusterId(), notNullValue());
 
             String logsFromKafka = systemUnderTest.getLogs();
-            assertThat(logsFromKafka, containsString("RaftManager nodeId=1"));
+            if (isLessThanKafka350(kafkaVersion)) {
+                assertThat(logsFromKafka, containsString("RaftManager nodeId=1"));
+            } else {
+                assertThat(logsFromKafka, containsString("ControllerServer id=1"));
+                assertThat(logsFromKafka, containsString("SocketServer listenerType=CONTROLLER, nodeId=1"));
+            }
 
             verify();
 
@@ -70,10 +75,9 @@ public class StrimziKafkaKraftContainerIT extends AbstractIT {
 
     @ParameterizedTest(name = "testStartContainerWithSomeConfiguration-{0}")
     @MethodSource("retrieveKafkaVersionsFile")
-    void testStartContainerWithSomeConfiguration(final String imageName) throws ExecutionException, InterruptedException, TimeoutException {
+    void testStartContainerWithSomeConfiguration(final String imageName, final String kafkaVersion) throws ExecutionException, InterruptedException, TimeoutException {
         assumeDocker();
         supportsKraftMode(imageName);
-
         try {
             Map<String, String> kafkaConfiguration = new HashMap<>();
 
@@ -92,7 +96,12 @@ public class StrimziKafkaKraftContainerIT extends AbstractIT {
 
             String logsFromKafka = systemUnderTest.getLogs();
 
-            assertThat(logsFromKafka, containsString("RaftManager nodeId=1"));
+            if (isLessThanKafka350(kafkaVersion)) {
+                assertThat(logsFromKafka, containsString("RaftManager nodeId=1"));
+            } else {
+                assertThat(logsFromKafka, containsString("ControllerServer id=1"));
+                assertThat(logsFromKafka, containsString("SocketServer listenerType=CONTROLLER, nodeId=1"));
+            }
             assertThat(logsFromKafka, containsString("log.cleaner.enable = false"));
             assertThat(logsFromKafka, containsString("log.cleaner.backoff.ms = 1000"));
             assertThat(logsFromKafka, containsString("ssl.enabled.protocols = [TLSv1]"));


### PR DESCRIPTION
This PR adds recently released Kafka versions. Also, it updates a few test cases where we need to check different logs because of change.  