### PR TITLE
Make maven sonatype plugin work also with Java 17, and publish for 17 only

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -42,7 +42,7 @@ jobs:
         parameters:
           JDK_VERSION: $(jdk_version)
 
-      - bash: mvn clean verify
+      - bash: mvn -Dfailsafe.rerunFailingTestsCount=3 clean verify
         env:
           # Test container optimization
           TESTCONTAINERS_RYUK_DISABLED: TRUE

--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -13,6 +13,10 @@ pr:
     include:
       - '*'
 
+variables:
+  isMain: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
+  isTagBranch: $[startsWith(variables['build.sourceBranch'], 'refs/tags/')]
+
 jobs:
   - job: 'main_branch_build'
     displayName: 'Build'
@@ -21,9 +25,9 @@ jobs:
     strategy:
       matrix:
         'java-11':
-          jdk_version: '11'
+          JDK_VERSION: '11'
         'java-17':
-          jdk_version: '17'
+          JDK_VERSION: '17'
     # Base system
     pool:
       vmImage: 'Ubuntu-22.04'
@@ -33,14 +37,14 @@ jobs:
         inputs:
           key: 'maven-cache | $(System.JobName) | **/pom.xml'
           restoreKeys: |
-              maven-cache | $(System.JobName)
-              maven-cache
+            maven-cache | $(System.JobName)
+            maven-cache
           path: $(HOME)/.m2/repository
         displayName: Maven cache
       - template: 'templates/steps/setup_docker.yaml'
       - template: 'templates/steps/setup_java.yaml'
         parameters:
-          JDK_VERSION: $(jdk_version)
+          JDK_VERSION: $(JDK_VERSION)
 
       - bash: mvn -Dfailsafe.rerunFailingTestsCount=3 clean verify
         env:
@@ -49,14 +53,9 @@ jobs:
           TESTCONTAINERS_CHECKS_DISABLE: TRUE
         displayName: "Strimzi test container build & verify"
 
-      - bash: ".azure/scripts/push_to_nexus.sh"
-        env:
-          GPG_PASSPHRASE: $(GPG_PASSPHRASE)
-          GPG_SIGNING_KEY: $(GPG_SIGNING_KEY)
-          NEXUS_USERNAME: $(NEXUS_USERNAME)
-          NEXUS_PASSWORD: $(NEXUS_PASSWORD)
-        displayName: "Push artifacts to Nexus repository"
-        condition: and(succeeded(), or(eq(variables['build.sourceBranch'], 'refs/heads/main'), startsWith(variables['build.sourceBranch'], 'refs/tags/')))
+      - template: 'templates/steps/push_artifacts.yaml'
+        parameters:
+          JDK_VERSION: variables.JDK_VERSION
 
       - task: PublishTestResults@2
         inputs:

--- a/.azure/templates/steps/push_artifacts.yaml
+++ b/.azure/templates/steps/push_artifacts.yaml
@@ -1,0 +1,13 @@
+parameters:
+  - name: JDK_VERSION
+    type: string
+    default: '17'
+steps:
+  - bash: ".azure/scripts/push_to_nexus.sh"
+    env:
+      GPG_PASSPHRASE: $(GPG_PASSPHRASE)
+      GPG_SIGNING_KEY: $(GPG_SIGNING_KEY)
+      NEXUS_USERNAME: $(NEXUS_USERNAME)
+      NEXUS_PASSWORD: $(NEXUS_PASSWORD)
+    displayName: "Push artifacts to Nexus repository"
+    condition: and(succeeded(), or(eq(variables.isMain, true), eq(variables.isTagBranch, true)), eq(${{ parameters.JDK_VERSION }}, '17'))

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <maven.source-plugin.version>3.0.1</maven.source-plugin.version>
         <maven.checkstyle.version>3.1.1</maven.checkstyle.version>
         <maven.gpg.version>1.6</maven.gpg.version>
-        <sonatype.nexus.staging>1.6.3</sonatype.nexus.staging>
+        <sonatype.nexus.staging>1.6.13</sonatype.nexus.staging>
 
         <!-- FIX VULNERABILITY VERSIONS  -->
         <commons-compress.version>1.21</commons-compress.version>


### PR DESCRIPTION
The older sonatype maven plugin (`1.6.3`) is failing when pushing artefacts using Java 17. This update should solve such a problem with the latest version `1.6.13`.

Basically a mirror of the https://github.com/strimzi/strimzi-kafka-operator/pull/7946. 

Plus I have added for flaky test cases (that it well try at least 3 times if they end up failing) 
Plus, publishing artefacts will done only in scope of Java 17 build