### PR TITLE
Add a new versions of Kafka 3.6.0 and 3.5.1

### DIFF
--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -87,9 +87,15 @@
         <!-- code quality -->
         <module name="MethodLength"/>
         <module name="ParameterNumber"/>
-        <module name="ClassDataAbstractionCoupling"/>
+        <module name="ClassDataAbstractionCoupling">
+            <!-- default is 7-->
+            <property name="max" value="10"/>
+        </module>
         <module name="BooleanExpressionComplexity"/>
-        <module name="ClassFanOutComplexity"/>
+        <module name="ClassFanOutComplexity">
+            <!-- default is 20-->
+            <property name="max" value="27"/>
+        </module>
         <module name="CyclomaticComplexity">
             <!-- default is 10-->
             <property name="max" value="11"/>

--- a/src/main/resources/kafka_versions.json
+++ b/src/main/resources/kafka_versions.json
@@ -6,6 +6,7 @@
     "3.2.3": "quay.io/strimzi-test-container/test-container:latest-kafka-3.2.3",
     "3.3.2": "quay.io/strimzi-test-container/test-container:latest-kafka-3.3.2",
     "3.4.1": "quay.io/strimzi-test-container/test-container:latest-kafka-3.4.1",
-    "3.5.0": "quay.io/strimzi-test-container/test-container:latest-kafka-3.5.0"
+    "3.5.1": "quay.io/strimzi-test-container/test-container:latest-kafka-3.5.1",
+    "3.6.0": "quay.io/strimzi-test-container/test-container:latest-kafka-3.6.0"
   }
 }

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaContainerIT.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaContainerIT.java
@@ -382,25 +382,25 @@ public class StrimziKafkaContainerIT extends AbstractIT {
                 producer.send(new ProducerRecord<>(topicName, recordKey, recordValue)).get();
 
                 Utils.waitFor("Consumer records are present", Duration.ofSeconds(10).toMillis(), Duration.ofMinutes(2).toMillis(),
-                        () -> {
-                            ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(100));
+                    () -> {
+                        ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(100));
 
-                            if (records.isEmpty()) {
-                                return false;
-                            }
+                        if (records.isEmpty()) {
+                            return false;
+                        }
 
-                            // verify count
-                            assertThat(records.count(), is(1));
+                        // verify count
+                        assertThat(records.count(), is(1));
 
-                            ConsumerRecord<String, String> consumerRecord = records.records(topicName).iterator().next();
+                        ConsumerRecord<String, String> consumerRecord = records.records(topicName).iterator().next();
 
-                            // verify content of the record
-                            assertThat(consumerRecord.topic(), is(topicName));
-                            assertThat(consumerRecord.key(), is(recordKey));
-                            assertThat(consumerRecord.value(), is(recordValue));
+                        // verify content of the record
+                        assertThat(consumerRecord.topic(), is(topicName));
+                        assertThat(consumerRecord.key(), is(recordKey));
+                        assertThat(consumerRecord.value(), is(recordValue));
 
-                            return true;
-                        });
+                        return true;
+                    });
             } catch (ExecutionException | InterruptedException | TimeoutException e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
This PR adds Kafka 3.5.1 and recently released Kafka 3.6.0 to our JSON file + one test case covering a functionality of Kafka container