### PR TITLE
Add a 3.7.0 Kafka version

### DIFF
--- a/src/main/resources/kafka_versions.json
+++ b/src/main/resources/kafka_versions.json
@@ -7,6 +7,7 @@
     "3.3.2": "quay.io/strimzi-test-container/test-container:latest-kafka-3.3.2",
     "3.4.1": "quay.io/strimzi-test-container/test-container:latest-kafka-3.4.1",
     "3.5.2": "quay.io/strimzi-test-container/test-container:latest-kafka-3.5.2",
-    "3.6.1": "quay.io/strimzi-test-container/test-container:latest-kafka-3.6.1"
+    "3.6.1": "quay.io/strimzi-test-container/test-container:latest-kafka-3.6.1",
+    "3.7.0": "quay.io/strimzi-test-container/test-container:latest-kafka-3.7.0"
   }
 }


### PR DESCRIPTION
This PR adds the latest Kafka version (3.7.0)