### PR TITLE
Fix pushing of artifacts to Nexus

### DIFF
--- a/.azure/scripts/push_to_nexus.sh
+++ b/.azure/scripts/push_to_nexus.sh
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
+set -e
+
+function cleanup() {
+  rm -rf signing.gpg
+  gpg --delete-keys
+  gpg --delete-secret-keys
+}
+
+# Run the cleanup on failure / exit
+trap cleanup EXIT
 
 export GPG_TTY=$(tty)
-
 echo $GPG_SIGNING_KEY | base64 -d > signing.gpg
 gpg --batch --import signing.gpg
 
 GPG_EXECUTABLE=gpg mvn $MVN_ARGS -DskipTests -s ./.azure/scripts/settings.xml -P ossrh verify deploy
 
-rm -rf signing.gpg
-gpg --delete-keys
-gpg --delete-secret-keys
+cleanup

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,12 @@
             <organizationUrl>https://www.redhat.com</organizationUrl>
         </developer>
         <developer>
+            <name>Lukáš Král</name>
+            <email>l.kral@outlook.com</email>
+            <organization>Red Hat</organization>
+            <organizationUrl>https://www.redhat.com</organizationUrl>
+        </developer>
+        <developer>
             <name>Maros Orsak</name>
             <email>morsak@redhat.com</email>
             <organization>Red Hat</organization>
@@ -111,7 +117,7 @@
         <maven.source-plugin.version>3.0.1</maven.source-plugin.version>
         <maven.checkstyle.version>3.1.1</maven.checkstyle.version>
         <maven.gpg.version>1.6</maven.gpg.version>
-        <sonatype.nexus.staging>1.6.13</sonatype.nexus.staging>
+        <sonatype.nexus.staging>1.7.0</sonatype.nexus.staging>
 
         <!-- FIX VULNERABILITY VERSIONS  -->
         <commons-compress.version>1.26.1</commons-compress.version>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Some changes at Sonatype broker the way we push the JAR artifacts to Sonatype Nexus. This PR fixes it by updating the Sonatype plugin. It also updates the script we use for it to make it fail in case of problems.

It also adds Lukas to the maintainer list where he was missing.