### PR TITLE
Add Kafka 3.7.1 version

### DIFF
--- a/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
@@ -173,7 +173,7 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
         if (this.useKraft) {
             super.waitingFor(Wait.forLogMessage(".*Transitioning from RECOVERY to RUNNING.*", 1));
         } else {
-            super.waitingFor(Wait.forLogMessage(".*Recorded new controller, from now on will use [node|broker].*", 1));
+            super.waitingFor(Wait.forLogMessage(".*Recorded new.*controller, from now on will use [node|broker].*", 1));
         }
         return this;
     }

--- a/src/main/resources/kafka_versions.json
+++ b/src/main/resources/kafka_versions.json
@@ -8,6 +8,6 @@
     "3.4.1": "quay.io/strimzi-test-container/test-container:latest-kafka-3.4.1",
     "3.5.2": "quay.io/strimzi-test-container/test-container:latest-kafka-3.5.2",
     "3.6.2": "quay.io/strimzi-test-container/test-container:latest-kafka-3.6.2",
-    "3.7.0": "quay.io/strimzi-test-container/test-container:latest-kafka-3.7.0"
+    "3.7.1": "quay.io/strimzi-test-container/test-container:latest-kafka-3.7.1"
   }
 }


### PR DESCRIPTION
This PR adds a Kafka 3.7.1 version.

Update:

So there is one needed change for 3.7.1 and higher versions.
```java
//  from: Recorded new controller, from now on will use node 
//  to  : Recorded new ZK controller, from now on will use
```

So I have updated the waiting message to match both of these logs :) 