### PR TITLE
Fix KRaft storage formating with UUID starting with dash

### DIFF
--- a/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
@@ -278,7 +278,7 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
             command += "bin/kafka-server-start.sh config/server.properties" + kafkaConfigurationOverride;
         } else {
             clusterId = this.randomUuid();
-            command += "bin/kafka-storage.sh format -t= \"" + clusterId + "\" -c config/kraft/server.properties \n";
+            command += "bin/kafka-storage.sh format -t=\"" + clusterId + "\" -c config/kraft/server.properties \n";
             command += "bin/kafka-server-start.sh config/kraft/server.properties" + kafkaConfigurationOverride;
         }
 

--- a/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
@@ -278,7 +278,7 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
             command += "bin/kafka-server-start.sh config/server.properties" + kafkaConfigurationOverride;
         } else {
             clusterId = this.randomUuid();
-            command += "bin/kafka-storage.sh format -t \"" + clusterId + "\" -c config/kraft/server.properties \n";
+            command += "bin/kafka-storage.sh format -t= \"" + clusterId + "\" -c config/kraft/server.properties \n";
             command += "bin/kafka-server-start.sh config/kraft/server.properties" + kafkaConfigurationOverride;
         }
 


### PR DESCRIPTION
This PR solves [1] issue. TLDR; when we generate UUID starting with `-.....` the command treats it as a new parameter and therefore fails. 
  
[1] - https://github.com/strimzi/test-container/issues/72