### PR TITLE
Add Kafka 3.8.0 to test containers

### DIFF
--- a/src/main/resources/kafka_versions.json
+++ b/src/main/resources/kafka_versions.json
@@ -8,6 +8,7 @@
     "3.4.1": "quay.io/strimzi-test-container/test-container:latest-kafka-3.4.1",
     "3.5.2": "quay.io/strimzi-test-container/test-container:latest-kafka-3.5.2",
     "3.6.2": "quay.io/strimzi-test-container/test-container:latest-kafka-3.6.2",
-    "3.7.1": "quay.io/strimzi-test-container/test-container:latest-kafka-3.7.1"
+    "3.7.1": "quay.io/strimzi-test-container/test-container:latest-kafka-3.7.1",
+    "3.8.0": "quay.io/strimzi-test-container/test-container:latest-kafka-3.8.0"
   }
 }


### PR DESCRIPTION
This PR adds recently released Kafka 3.8.0 to our test container.