### PR TITLE
Transfer only contents of Kafka and ZooKeeper properties files

### DIFF
--- a/src/main/java/io/strimzi/test/container/StrimziZookeeperContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziZookeeperContainer.java
@@ -112,7 +112,8 @@ public class StrimziZookeeperContainer extends GenericContainer<StrimziZookeeper
      * @return StrimziZookeeperContainer instance
      */
     public StrimziZookeeperContainer withZooKeeperPropertiesFile(final MountableFile zooKeeperPropertiesFile) {
-        withCopyFileToContainer(zooKeeperPropertiesFile, "/opt/kafka/config/zookeeper.properties");
+        Utils.asTransferableBytes(zooKeeperPropertiesFile)
+            .ifPresent(properties -> withCopyToContainer(properties, "/opt/kafka/config/zookeeper.properties"));
         return this;
     }
 


### PR DESCRIPTION
I've been playing around with this library to investigate listener configurations (likely helpful to #63), but I am unable to run the tests in an environment with podman. It turns out that copying a `MountableFile` to the containers preserves the user and group Ids from the host machine via an intermediate tar file. This fails with podman due to the chown command not being allowed.

The change proposed here is to read the contents of the `MountableFile` prior to copying into the container. This drops the user and group information, which should not be relevant. 

An additional change is to delay copying the Kafka properties until the container is starting, which allows for `withKraft` and `withServerProperties` to be called in any order.