### PR TITLE
Fix pushing arctifacts because of not resolved version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <maven.source-plugin.version>3.2.1</maven.source-plugin.version>
         <maven.checkstyle.version>3.3.0</maven.checkstyle.version>
         <maven.gpg.version>1.7.1</maven.gpg.version>
-        <sonatype.nexus.staging>1.7.1</sonatype.nexus.staging>
+        <sonatype.nexus.staging>1.7.0</sonatype.nexus.staging>
 
         <!-- FIX VULNERABILITY VERSIONS  -->
         <commons-compress.version>1.26.1</commons-compress.version>


### PR DESCRIPTION
In the previous dependency bump of versions, I accidentally typed the wrong version of the nexus dependency (i.e., it should be 1.7.0 instead of 1.7.1). 

This PR should fix the main branch during pushing.