### PR TITLE
Add ability to enable shared network in `StrimziKafkaCluster`

### DIFF
--- a/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
@@ -35,10 +35,9 @@ public class StrimziKafkaCluster implements KafkaContainer {
 
     // instance attributes
     private final int brokersNum;
+    private final Network network;
     private final StrimziZookeeperContainer zookeeper;
     private final Collection<KafkaContainer> brokers;
-
-    private Network network;
 
     /**
      * Constructor for @StrimziKafkaCluster class, which allows you to specify number of brokers @see{brokersNum},

--- a/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
@@ -35,9 +35,10 @@ public class StrimziKafkaCluster implements KafkaContainer {
 
     // instance attributes
     private final int brokersNum;
-    private final Network network;
     private final StrimziZookeeperContainer zookeeper;
     private final Collection<KafkaContainer> brokers;
+
+    private Network network;
 
     /**
      * Constructor for @StrimziKafkaCluster class, which allows you to specify number of brokers @see{brokersNum},
@@ -51,11 +52,13 @@ public class StrimziKafkaCluster implements KafkaContainer {
      * @param internalTopicReplicationFactor internal topics
      * @param additionalKafkaConfiguration additional Kafka configuration
      * @param proxyContainer Proxy container
+     * @param enableSharedNetwork enable Kafka cluster to use a shared Docker network.
      */
     public StrimziKafkaCluster(final int brokersNum,
                                final int internalTopicReplicationFactor,
                                final Map<String, String> additionalKafkaConfiguration,
-                               final ToxiproxyContainer proxyContainer) {
+                               final ToxiproxyContainer proxyContainer,
+                               final boolean enableSharedNetwork) {
         if (brokersNum <= 0) {
             throw new IllegalArgumentException("brokersNum '" + brokersNum + "' must be greater than 0");
         }
@@ -64,7 +67,7 @@ public class StrimziKafkaCluster implements KafkaContainer {
         }
 
         this.brokersNum = brokersNum;
-        this.network = Network.newNetwork();
+        this.network = enableSharedNetwork ? Network.SHARED : Network.newNetwork();
 
         this.zookeeper = new StrimziZookeeperContainer()
             .withNetwork(this.network);
@@ -117,7 +120,7 @@ public class StrimziKafkaCluster implements KafkaContainer {
     public StrimziKafkaCluster(final int brokersNum,
                                final int internalTopicReplicationFactor,
                                final Map<String, String> additionalKafkaConfiguration) {
-        this(brokersNum, internalTopicReplicationFactor, additionalKafkaConfiguration, null);
+        this(brokersNum, internalTopicReplicationFactor, additionalKafkaConfiguration, null, false);
     }
 
     /**
@@ -126,7 +129,7 @@ public class StrimziKafkaCluster implements KafkaContainer {
      * @param brokersNum number of brokers
      */
     public StrimziKafkaCluster(final int brokersNum) {
-        this(brokersNum, brokersNum, null, null);
+        this(brokersNum, brokersNum, null, null, false);
     }
 
     /**
@@ -136,7 +139,17 @@ public class StrimziKafkaCluster implements KafkaContainer {
      * @param proxyContainer Proxy container
      */
     public StrimziKafkaCluster(final int brokersNum, final ToxiproxyContainer proxyContainer) {
-        this(brokersNum, brokersNum, null, proxyContainer);
+        this(brokersNum, brokersNum, null, proxyContainer, false);
+    }
+
+    /**
+     * Constructor of StrimziKafkaCluster with proxy container
+     *
+     * @param brokersNum number of brokers to be deployed
+     * @param enableSharedNetwork enable Kafka cluster to use a shared Docker network.
+     */
+    public StrimziKafkaCluster(final int brokersNum, final boolean enableSharedNetwork) {
+        this(brokersNum, brokersNum, null, null, enableSharedNetwork);
     }
 
     /**

--- a/src/test/java/io/strimzi/test/container/AbstractIT.java
+++ b/src/test/java/io/strimzi/test/container/AbstractIT.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.provider.Arguments;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,5 +50,10 @@ public class AbstractIT {
 
     protected boolean isLessThanKafka350(final String kafkaVersion) {
         return KafkaVersionService.KafkaVersion.compareVersions(kafkaVersion, "3.5.0") == -1;
+    }
+
+    @BeforeEach
+    void setUpEach() {
+        assumeDocker();
     }
 }

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaClusterIT.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaClusterIT.java
@@ -26,7 +26,6 @@ import org.hamcrest.CoreMatchers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.ToxiproxyContainer;
@@ -73,7 +72,7 @@ public class StrimziKafkaClusterIT extends AbstractIT {
             systemUnderTest.start();
 
             verifyReadinessOfKafkaCluster();
-       } finally {
+        } finally {
             systemUnderTest.stop();
         }
     }

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaClusterTest.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaClusterTest.java
@@ -14,26 +14,26 @@ public class StrimziKafkaClusterTest {
     @Test
     void testKafkaClusterNegativeOrZeroNumberOfNodes() {
         assertThrows(IllegalArgumentException.class, () -> new StrimziKafkaCluster(
-            0, 1, null, null));
+            0, 1, null, null, false));
         assertThrows(IllegalArgumentException.class, () -> new StrimziKafkaCluster(
-            -1, 1, null, null));
+            -1, 1, null, null, false));
     }
 
     @Test
     void testKafkaClusterPossibleNumberOfNodes() {
         assertDoesNotThrow(() -> new StrimziKafkaCluster(
-            1, 1, null, null));
+            1, 1, null, null, false));
         assertDoesNotThrow(() -> new StrimziKafkaCluster(
-            3, 3, null, null));
+            3, 3, null, null, false));
         assertDoesNotThrow(() -> new StrimziKafkaCluster(
-            10, 3, null, null));
+            10, 3, null, null, false));
     }
 
     @Test
     void testNegativeOrMoreReplicasThanAvailableOfKafkaBrokersInternalReplicationError() {
         assertThrows(IllegalArgumentException.class, () -> new StrimziKafkaCluster(
-            0, 0, null, null));
+            0, 0, null, null, false));
         assertThrows(IllegalArgumentException.class, () -> new StrimziKafkaCluster(
-            3, 5, null, null));
+            3, 5, null, null, false));
     }
 }

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaContainerIT.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaContainerIT.java
@@ -63,8 +63,6 @@ public class StrimziKafkaContainerIT extends AbstractIT {
     @ParameterizedTest(name = "testStartContainerWithEmptyConfiguration-{0}")
     @MethodSource("retrieveKafkaVersionsFile")
     void testStartContainerWithEmptyConfiguration(final String imageName) {
-        assumeDocker();
-
         try (StrimziKafkaContainer systemUnderTest = new StrimziKafkaContainer(imageName)
                 .withBrokerId(1)
                 .waitForRunning()) {
@@ -79,8 +77,6 @@ public class StrimziKafkaContainerIT extends AbstractIT {
     @ParameterizedTest(name = "testStartContainerWithSomeConfiguration-{0}")
     @MethodSource("retrieveKafkaVersionsFile")
     void testStartContainerWithSomeConfiguration(final String imageName) {
-        assumeDocker();
-
         Map<String, String> kafkaConfiguration = new HashMap<>();
 
         kafkaConfiguration.put("log.cleaner.enable", "false");
@@ -109,8 +105,6 @@ public class StrimziKafkaContainerIT extends AbstractIT {
     @ParameterizedTest(name = "testStartContainerWithFixedExposedPort-{0}")
     @MethodSource("retrieveKafkaVersionsFile")
     void testStartContainerWithFixedExposedPort(final String imageName) {
-        assumeDocker();
-
         systemUnderTest = new StrimziKafkaContainer(imageName)
                 .withPort(9092)
                 .waitForRunning();
@@ -125,8 +119,6 @@ public class StrimziKafkaContainerIT extends AbstractIT {
     @ParameterizedTest(name = "testStartContainerWithSSLBootstrapServers-{0}")
     @MethodSource("retrieveKafkaVersionsFile")
     void testStartContainerWithSSLBootstrapServers(final String imageName) {
-        assumeDocker();
-
         systemUnderTest = new StrimziKafkaContainer(imageName)
                 .waitForRunning()
                 .withBootstrapServers(c -> String.format("SSL://%s:%s", c.getHost(), c.getMappedPort(9092)));
@@ -141,8 +133,6 @@ public class StrimziKafkaContainerIT extends AbstractIT {
     @ParameterizedTest(name = "testStartContainerWithServerProperties-{0}")
     @MethodSource("retrieveKafkaVersionsFile")
     void testStartContainerWithServerProperties(final String imageName) {
-        assumeDocker();
-
         systemUnderTest = new StrimziKafkaContainer(imageName)
                 .waitForRunning()
                 .withServerProperties(MountableFile.forClasspathResource("server.properties"));
@@ -161,8 +151,6 @@ public class StrimziKafkaContainerIT extends AbstractIT {
 
     @Test
     void testStartContainerWithStrimziKafkaImage() {
-        assumeDocker();
-
         // explicitly set strimzi.test-container.kafka.custom.image
         String imageName = "quay.io/strimzi/kafka:0.27.1-kafka-3.0.0";
         System.setProperty("strimzi.test-container.kafka.custom.image", imageName);
@@ -184,8 +172,6 @@ public class StrimziKafkaContainerIT extends AbstractIT {
 
     @Test
     void testStartContainerWithCustomImage() {
-        assumeDocker();
-
         String imageName = "quay.io/strimzi/kafka:0.27.1-kafka-3.0.0";
         systemUnderTest = new StrimziKafkaContainer(imageName)
                 .waitForRunning();
@@ -201,8 +187,6 @@ public class StrimziKafkaContainerIT extends AbstractIT {
 
     @Test
     void testStartContainerWithCustomNetwork() {
-        assumeDocker();
-
         Network network = Network.newNetwork();
 
         systemUnderTest = new StrimziKafkaContainer()
@@ -220,8 +204,6 @@ public class StrimziKafkaContainerIT extends AbstractIT {
 
     @Test
     void testUnsupportedKafkaVersion() {
-        assumeDocker();
-
         try {
             systemUnderTest = new StrimziKafkaContainer()
                 .withKafkaVersion("2.4.0")
@@ -236,8 +218,6 @@ public class StrimziKafkaContainerIT extends AbstractIT {
     @ParameterizedTest(name = "testKafkaContainerConnectFromOutsideToInternalZooKeeper-{0}")
     @MethodSource("retrieveKafkaVersionsFile")
     void testKafkaContainerConnectFromOutsideToInternalZooKeeper() {
-        assumeDocker();
-
         try {
             systemUnderTest = new StrimziKafkaContainer()
                 .waitForRunning();
@@ -267,8 +247,6 @@ public class StrimziKafkaContainerIT extends AbstractIT {
     @ParameterizedTest(name = "testKafkaContainerInternalCommunicationWithInternalZooKeeper-{0}")
     @MethodSource("retrieveKafkaVersionsFile")
     void testKafkaContainerInternalCommunicationWithInternalZooKeeper() throws IOException, InterruptedException {
-        assumeDocker();
-
         try {
             systemUnderTest = new StrimziKafkaContainer()
                 .waitForRunning();
@@ -291,8 +269,6 @@ public class StrimziKafkaContainerIT extends AbstractIT {
     @ParameterizedTest(name = "testIllegalStateUsingInternalZooKeeperWithKraft-{0}")
     @MethodSource("retrieveKafkaVersionsFile")
     void testIllegalStateUsingInternalZooKeeperWithKraft() {
-        assumeDocker();
-
         systemUnderTest = new StrimziKafkaContainer()
             .withKraft()
             .waitForRunning();
@@ -303,8 +279,6 @@ public class StrimziKafkaContainerIT extends AbstractIT {
     @ParameterizedTest(name = "testIllegalStateUsingInternalZooKeeperWithExternalZooKeeper-{0}")
     @MethodSource("retrieveKafkaVersionsFile")
     void testIllegalStateUsingInternalZooKeeperWithExternalZooKeeper() {
-        assumeDocker();
-
         systemUnderTest = new StrimziKafkaContainer()
             // we do not need to spin-up instance of StrimziZooKeeperContainer
             .withExternalZookeeperConnect("zookeeper:2181")
@@ -316,8 +290,6 @@ public class StrimziKafkaContainerIT extends AbstractIT {
     @ParameterizedTest(name = "testStartBrokerWithProxyContainer-{0}")
     @MethodSource("retrieveKafkaVersionsFile")
     void testStartBrokerWithProxyContainer(final String imageName) {
-        assumeDocker();
-
         ToxiproxyContainer proxyContainer = new ToxiproxyContainer(
                 DockerImageName.parse("ghcr.io/shopify/toxiproxy:2.6.0")
                         .asCompatibleSubstituteFor("shopify/toxiproxy"));

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaKraftContainerIT.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaKraftContainerIT.java
@@ -44,7 +44,6 @@ public class StrimziKafkaKraftContainerIT extends AbstractIT {
     @ParameterizedTest(name = "testStartContainerWithEmptyConfiguration-{0}")
     @MethodSource("retrieveKafkaVersionsFile")
     void testStartContainerWithEmptyConfiguration(final String imageName, final String kafkaVersion) throws ExecutionException, InterruptedException, TimeoutException {
-        assumeDocker();
         supportsKraftMode(imageName);
 
         try {
@@ -76,7 +75,6 @@ public class StrimziKafkaKraftContainerIT extends AbstractIT {
     @ParameterizedTest(name = "testStartContainerWithSomeConfiguration-{0}")
     @MethodSource("retrieveKafkaVersionsFile")
     void testStartContainerWithSomeConfiguration(final String imageName, final String kafkaVersion) throws ExecutionException, InterruptedException, TimeoutException {
-        assumeDocker();
         supportsKraftMode(imageName);
         try {
             Map<String, String> kafkaConfiguration = new HashMap<>();
@@ -115,8 +113,6 @@ public class StrimziKafkaKraftContainerIT extends AbstractIT {
 
     @Test
     void testUnsupportedKRaftUsingKafkaVersion() {
-        assumeDocker();
-
         try {
             systemUnderTest = new StrimziKafkaContainer()
                 .withKafkaVersion("2.8.2")
@@ -133,8 +129,6 @@ public class StrimziKafkaKraftContainerIT extends AbstractIT {
 
     @Test
     void testUnsupportedKRaftUsingImageName() {
-        assumeDocker();
-
         try {
             systemUnderTest = new StrimziKafkaContainer("quay.io/strimzi-test-container/test-container:latest-kafka-2.8.2")
                 .withBrokerId(1)

--- a/src/test/java/io/strimzi/test/container/StrimziZookeeperContainerIT.java
+++ b/src/test/java/io/strimzi/test/container/StrimziZookeeperContainerIT.java
@@ -72,8 +72,6 @@ public class StrimziZookeeperContainerIT extends AbstractIT {
     @ParameterizedTest(name = "testStartContainerWithZooKeeperProperties-{0}")
     @MethodSource("retrieveKafkaVersionsFile")
     void testStartContainerWithZooKeeperProperties(final String imageName) {
-        assumeDocker();
-
         try {
             systemUnderTest = new StrimziZookeeperContainer(imageName)
                 .withZooKeeperPropertiesFile(MountableFile.forClasspathResource("zookeeper.properties"));


### PR DESCRIPTION
This PR tries to address https://github.com/strimzi/test-container/issues/83 by adding a `boolean sharedNetwork`. With such change a user is able to run Kafka cluster with shared network if needed. 