### PR TITLE
Add possiblity to specify Kafka version in `StrimziKafkaCluster`

### DIFF
--- a/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
@@ -517,4 +517,8 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
         }
         return this.proxy;
     }
+
+    /* test */ String getKafkaVersion() {
+        return this.kafkaVersion;
+    }
 }


### PR DESCRIPTION
This PR allows specifying the Kafka version in `StrimziKafkaCluster`. Moreover, I have added a few UTs to cover such changes with some aux methods only dedicated to tests. Additionally, I have only made such a change for `Builder` to allow users to specify such a version (for those users, who are using old constructors we still use the default/latest version).