### PR TITLE
Add KRaft readiness check in StrimziKafkaCluster

### DIFF
--- a/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
@@ -605,4 +605,8 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
     /* test */ String getKafkaVersion() {
         return this.kafkaVersion;
     }
+
+    /* test */ int getBrokerId() {
+        return brokerId;
+    }
 }


### PR DESCRIPTION
This PR adds a KRaft readiness check within `StrimziKafkaCluster`. Currently `waitForRunning()` inside each `StrimziKafkaContainer` is not enough because it does not wait on Quorum form but only for `Transitioning from RECOVERY to RUNNING` which is only correct when we use single-node. In case of multi-node we need to wait until quorum is formed and ready.