### PR TITLE
Fix start() in StrimziKafkaCluster to propagate exception correctly

### DIFF
--- a/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
@@ -392,7 +392,7 @@ public class StrimziKafkaCluster implements KafkaContainer {
             Startables.deepStart(startables).get(60, TimeUnit.SECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             Thread.currentThread().interrupt();
-            e.printStackTrace();
+            throw new RuntimeException("Failed to start Kafka containers", e);
         }
 
         if (this.isZooKeeperBasedKafkaCluster()) {
@@ -411,8 +411,7 @@ public class StrimziKafkaCluster implements KafkaContainer {
                         return brokers != null && brokers.split(",").length == this.brokersNum;
                     } catch (IOException | InterruptedException e) {
                         Thread.currentThread().interrupt();
-                        e.printStackTrace();
-                        return false;
+                        throw new RuntimeException("Failed to execute command in ZooKeeper container", e);
                     }
                 });
         } else if (this.isKraftKafkaCluster()) {


### PR DESCRIPTION
This PR handles exceptions correctly by throwing them instead of just calling printStackTrace(). Also, now it throws a more informative error message than before, as stated in issue #80. 