### PR TITLE
Fix memory problems inside test suite

### DIFF
--- a/src/test/java/io/strimzi/test/container/StrimziKafkaContainerIT.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaContainerIT.java
@@ -17,6 +17,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
@@ -376,6 +377,13 @@ public class StrimziKafkaContainerIT extends AbstractIT {
             } catch (ExecutionException | InterruptedException | TimeoutException e) {
                 throw new RuntimeException(e);
             }
+        }
+    }
+
+    @AfterEach
+    void afterEach() {
+        if (this.systemUnderTest != null) {
+            this.systemUnderTest.stop();
         }
     }
 }

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaContainerIT.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaContainerIT.java
@@ -312,6 +312,7 @@ public class StrimziKafkaContainerIT extends AbstractIT {
                 .waitForRunning();
         systemUnderTest.start();
         assertThrows(IllegalStateException.class, () -> systemUnderTest.getProxy());
+        systemUnderTest.stop();
     }
 
     @Test

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaKraftContainerIT.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaKraftContainerIT.java
@@ -14,6 +14,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -170,6 +171,13 @@ public class StrimziKafkaKraftContainerIT extends AbstractIT {
             assertThat(records.records(topic).get(0).value(), equalTo("1"));
             assertThat(records.records(topic).get(1).value(), equalTo("2"));
             assertThat(records.records(topic).get(2).value(), equalTo("3"));
+        }
+    }
+
+    @AfterEach
+    void afterEach() {
+        if (this.systemUnderTest != null) {
+            this.systemUnderTest.stop();
         }
     }
 }


### PR DESCRIPTION
In the Add proxy container configuration (#44), we forgot to add stop(). That causes containers to run during all other test cases. Only recently (with more Kafka versions) it showed that we are out of memory in Azure CI:
```java
##[warning]Free memory is lower than 5%; Currently used: 95.10%
##[warning]Free memory is lower than 5%; Currently used: 95.10%
```

This should fix the problem above.

Note: 

I think we should double-check before each test that none containers are running to avoid this in the future.