### PR TITLE
Bump main to 0.110.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>io.strimzi</groupId>
     <artifactId>strimzi-test-container</artifactId>
     <packaging>jar</packaging>
-    <version>0.109.0-SNAPSHOT</version>
+    <version>0.110.0-SNAPSHOT</version>
 
     <licenses>
         <license>


### PR DESCRIPTION
After release of strimzi-test-container 0.109.0 is done, we should update pom.xml to newer version.