### PR TITLE
Update pitest and increase mutation coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <maven.gpg.version>1.6</maven.gpg.version>
         <sonatype.nexus.staging>1.7.0</sonatype.nexus.staging>
         <pit-junit-plugin.version>1.2.1</pit-junit-plugin.version>
-        <pit-plugin.version>1.17.0</pit-plugin.version>
+        <pit-plugin.version>1.17.2</pit-plugin.version>
 
         <!-- FIX VULNERABILITY VERSIONS  -->
         <commons-compress.version>1.26.1</commons-compress.version>
@@ -454,7 +454,7 @@
                         <avoidCallsTo>org.slf4j</avoidCallsTo>
                         <avoidCallsTo>org.apache.commons.logging</avoidCallsTo>
                     </avoidCallsTo>
-                    <mutationThreshold>81</mutationThreshold>
+                    <mutationThreshold>91</mutationThreshold>
                     <coverageThreshold>72</coverageThreshold>
                     <verbose>true</verbose>
                 </configuration>


### PR DESCRIPTION
As https://github.com/hcoles/pitest/releases/tag/1.17.2 is released with the fix [1] of excluding lambdas (and nested lambdas). We can increase the mutation coverage of our test suite.

[1] - https://github.com/hcoles/pitest/pull/1362