### PR TITLE
Fix Intermittent Kafka Quorum Formation Issue

### DIFF
--- a/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
@@ -274,6 +274,7 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
                 LOGGER.info("New `cluster.id` has been generated: {}", this.clusterId);
             }
 
+            command += "cat /opt/kafka/config/kraft/server.properties\n";
             command += "bin/kafka-storage.sh format -t=\"" + this.clusterId + "\" -c /opt/kafka/config/kraft/server.properties \n";
             command += "bin/kafka-server-start.sh /opt/kafka/config/kraft/server.properties \n";
         }
@@ -374,7 +375,7 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
                     advertisedListeners.append(",")
                         .append(controllerListenerName)
                         .append("://")
-                        .append(getHost())
+                        .append(NETWORK_ALIAS_PREFIX + this.brokerId)
                         .append(":")
                         .append(controllerPort);
                 }

--- a/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
@@ -274,7 +274,6 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
                 LOGGER.info("New `cluster.id` has been generated: {}", this.clusterId);
             }
 
-            command += "cat /opt/kafka/config/kraft/server.properties\n";
             command += "bin/kafka-storage.sh format -t=\"" + this.clusterId + "\" -c /opt/kafka/config/kraft/server.properties \n";
             command += "bin/kafka-server-start.sh /opt/kafka/config/kraft/server.properties \n";
         }

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaContainerMockTest.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaContainerMockTest.java
@@ -55,7 +55,7 @@ public class StrimziKafkaContainerMockTest {
             .buildListenersConfig(containerInfo);
 
         String expectedListeners = "PLAINTEXT://0.0.0.0:9092,BROKER1://0.0.0.0:9091,CONTROLLER://0.0.0.0:9094";
-        String expectedAdvertisedListeners = "PLAINTEXT://localhost:9092,BROKER1://172.17.0.2:9091,CONTROLLER://localhost:9094";
+        String expectedAdvertisedListeners = "PLAINTEXT://localhost:9092,BROKER1://172.17.0.2:9091,CONTROLLER://broker-0:9094";
 
         assertThat(listenersConfig[0], is(expectedListeners));
         assertThat(listenersConfig[1], is(expectedAdvertisedListeners));
@@ -152,7 +152,7 @@ public class StrimziKafkaContainerMockTest {
         String[] listenersConfig = kafkaContainer.buildListenersConfig(containerInfo);
 
         String expectedListeners = "PLAINTEXT://0.0.0.0:9092,BROKER1://0.0.0.0:9091,CONTROLLER://0.0.0.0:9094";
-        String expectedAdvertisedListeners = "PLAINTEXT://localhost:9092,BROKER1://172.17.0.2:9091,CONTROLLER://localhost:9094";
+        String expectedAdvertisedListeners = "PLAINTEXT://localhost:9092,BROKER1://172.17.0.2:9091,CONTROLLER://broker-0:9094";
 
         assertThat(listenersConfig[0], is(expectedListeners));
         assertThat(listenersConfig[1], is(expectedAdvertisedListeners));


### PR DESCRIPTION
This PR addresses an intermittent issue where Kafka brokers fail to form a quorum due to mismatched voter keys in the Raft consensus algorithm. The problem occurs approximately 1 out of every 5 test runs (which I tried)...

Brokers occasionally fail to form a quorum, with logs showing repeated messages like:
```java
Leader sent a voter key... that doesn't match the local key...; returning INVALID_VOTER_KEY
```

The advertised listeners for the CONTROLLER listener are set to localhost (using `getHost()` method), while controller.quorum. voters specify hostnames like broker-0, broker-1, etc. This mismatch leads to brokers advertising their controller endpoints incorrectly, causing other brokers to attempt connections to localhost instead of the correct broker addresses.

Using localhost for the CONTROLLER listener causes brokers to incorrectly attempt to connect to themselves rather than the intended broker, due to localhost resolving to 127.0.0.1.

I have verified such a change in a test case which failed once in 5 runs and now it's working (20 runs without any issue):

<img width="441" alt="image" src="https://github.com/user-attachments/assets/16e0f783-0502-4315-8540-4a1dc1e54ac1">
 