### PR TITLE
Check node and broker id equality in KRaft mode on start up and not in broker.id setter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -455,7 +455,7 @@
                         <avoidCallsTo>org.apache.commons.logging</avoidCallsTo>
                     </avoidCallsTo>
                     <mutationThreshold>91</mutationThreshold>
-                    <coverageThreshold>72</coverageThreshold>
+                    <coverageThreshold>71</coverageThreshold>
                     <verbose>true</verbose>
                 </configuration>
             </plugin>

--- a/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
@@ -253,6 +253,12 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
             this.nodeId = this.brokerId;
         }
 
+        if (this.useKraft) {
+            if (this.brokerId != this.nodeId) {
+                throw new IllegalStateException("`broker.id` and `node.id` must have the same value!");
+            }
+        }
+
         final String[] listenersConfig = this.buildListenersConfig(containerInfo);
         final Properties defaultServerProperties = this.buildDefaultServerProperties(
             listenersConfig[0],
@@ -654,10 +660,6 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
      * @return StrimziKafkaContainer instance
      */
     public StrimziKafkaContainer withBrokerId(final int brokerId) {
-        if (this.useKraft && this.brokerId != this.nodeId) {
-            throw new IllegalStateException("`broker.id` and `node.id` must have same value!");
-        }
-
         this.brokerId = brokerId;
         return self();
     }

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaContainerTest.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaContainerTest.java
@@ -179,17 +179,6 @@ class StrimziKafkaContainerTest {
     }
 
     @Test
-    void testWithBrokerIdThrowsExceptionWhenKraftAndIdsMismatch() {
-        kafkaContainer.withKraft();
-        kafkaContainer.withNodeId(1);
-
-        IllegalStateException exception = assertThrows(IllegalStateException.class,
-            () -> kafkaContainer.withBrokerId(2));
-
-        assertThat(exception.getMessage(), containsString("`broker.id` and `node.id` must have same value!"));
-    }
-
-    @Test
     void testWithNodeIdReturnsSelf() {
         StrimziKafkaContainer result = kafkaContainer.withNodeId(1);
         assertSame(kafkaContainer, result, "withNodeId() should return the same instance for method chaining.");


### PR DESCRIPTION
Fixes https://github.com/strimzi/test-container/issues/124