### PR TITLE
Update version snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>io.strimzi</groupId>
     <artifactId>strimzi-test-container</artifactId>
     <packaging>jar</packaging>
-    <version>0.110.0-SNAPSHOT</version>
+    <version>0.111.0-SNAPSHOT</version>
 
     <licenses>
         <license>


### PR DESCRIPTION
This PR updates the main snapshot as we currently released the 0.110.0 strimzi test container.