### PR TITLE
Remove un-necessary enabledKraft option

### DIFF
--- a/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
@@ -45,7 +45,6 @@ public class StrimziKafkaCluster implements KafkaContainer {
     private final ToxiproxyContainer proxyContainer;
     private final boolean enableSharedNetwork;
     private final String kafkaVersion;
-    private final boolean enableKraft;
 
     // not editable
     private final Network network;
@@ -60,7 +59,6 @@ public class StrimziKafkaCluster implements KafkaContainer {
         this.additionalKafkaConfiguration = builder.additionalKafkaConfiguration;
         this.proxyContainer = builder.proxyContainer;
         this.kafkaVersion = builder.kafkaVersion;
-        this.enableKraft = builder.enableKRaft;
         this.clusterId = builder.clusterId;
 
         validateBrokerNum(this.brokersNum);


### PR DESCRIPTION
This PR removes the unnecessary option `private final boolean enableKraft;` from the StrimziKafkaCluster, which I accidentally forgot when I removed ZK. 