### PR TITLE
Expose GenericContainer from StrimziKafkaCluster via getNodes() method

### DIFF
--- a/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
@@ -8,6 +8,7 @@ import com.groupcdg.pitest.annotations.DoNotMutate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Container;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 import org.testcontainers.lifecycle.Startables;
@@ -49,7 +50,7 @@ public class StrimziKafkaCluster implements KafkaContainer {
 
     // not editable
     private final Network network;
-    private Collection<KafkaContainer> brokers;
+    private Collection<KafkaContainer> nodes;
     private final String clusterId;
 
     private StrimziKafkaCluster(StrimziKafkaClusterBuilder builder) {
@@ -88,7 +89,7 @@ public class StrimziKafkaCluster implements KafkaContainer {
         }
 
         // multi-node set up
-        this.brokers = IntStream
+        this.nodes = IntStream
             .range(0, this.brokersNum)
             .mapToObj(brokerId -> {
                 LOGGER.info("Starting broker with id {}", brokerId);
@@ -228,10 +229,24 @@ public class StrimziKafkaCluster implements KafkaContainer {
 
     /**
      * Get collection of Strimzi kafka containers
+     *
+     * @deprecated use {@link #getNodes()} instead.
      * @return collection of Strimzi kafka containers
      */
+    @Deprecated
     public Collection<KafkaContainer> getBrokers() {
-        return this.brokers;
+        return this.nodes;
+    }
+
+    /**
+     * Returns the underlying GenericContainer instances for Kafka brokers.
+     *
+     * @return Collection of GenericContainer representing the brokers
+     */
+    public Collection<GenericContainer<?>> getNodes() {
+        return nodes.stream()
+            .map(node -> (GenericContainer<?>) node)
+            .collect(Collectors.toList());
     }
 
     /**
@@ -240,14 +255,14 @@ public class StrimziKafkaCluster implements KafkaContainer {
      */
     @DoNotMutate
     public String getNetworkBootstrapServers() {
-        return brokers.stream()
+        return nodes.stream()
                 .map(broker -> ((StrimziKafkaContainer) broker).getNetworkBootstrapServers())
                 .collect(Collectors.joining(","));
     }
 
     @Override
     public String getBootstrapServers() {
-        return brokers.stream()
+        return nodes.stream()
             .map(KafkaContainer::getBootstrapServers)
             .collect(Collectors.joining(","));
     }
@@ -277,7 +292,7 @@ public class StrimziKafkaCluster implements KafkaContainer {
     @Override
     @DoNotMutate
     public void start() {
-        Stream<KafkaContainer> startables = this.brokers.stream();
+        Stream<KafkaContainer> startables = this.nodes.stream();
         try {
             Startables.deepStart(startables).get(60, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
@@ -293,7 +308,7 @@ public class StrimziKafkaCluster implements KafkaContainer {
         Utils.waitFor("Kafka brokers to form a quorum", Duration.ofSeconds(1), Duration.ofMinutes(1),
             () -> {
                 try {
-                    for (KafkaContainer kafkaContainer : this.brokers) {
+                    for (KafkaContainer kafkaContainer : this.nodes) {
                         Container.ExecResult result = ((StrimziKafkaContainer) kafkaContainer).execInContainer(
                             "bash", "-c",
                             "bin/kafka-metadata-quorum.sh --bootstrap-server localhost:" + StrimziKafkaContainer.INTER_BROKER_LISTENER_PORT + " describe --status"
@@ -338,7 +353,7 @@ public class StrimziKafkaCluster implements KafkaContainer {
     @DoNotMutate
     public void stop() {
         // stop all kafka containers in parallel
-        this.brokers.stream()
+        this.nodes.stream()
             .parallel()
             .forEach(KafkaContainer::stop);
     }

--- a/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
@@ -239,9 +239,10 @@ public class StrimziKafkaCluster implements KafkaContainer {
     }
 
     /**
-     * Returns the underlying GenericContainer instances for Kafka brokers.
+     * Returns the underlying GenericContainer instances for all Kafka nodes in the cluster.
+     * In the current setup, all nodes are mixed-role (i.e., each acts as both broker and controller) in KRaft mode.
      *
-     * @return Collection of GenericContainer representing the brokers
+     * @return Collection of GenericContainer representing the cluster nodes
      */
     public Collection<GenericContainer<?>> getNodes() {
         return nodes.stream()

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaClusterTest.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaClusterTest.java
@@ -366,6 +366,7 @@ public class StrimziKafkaClusterTest {
         assertThat(servers.length, CoreMatchers.is(3));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     void testGetNodesAndBrokersReturnsGenericContainers() {
         StrimziKafkaCluster cluster = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaClusterTest.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaClusterTest.java
@@ -7,6 +7,7 @@ package io.strimzi.test.container;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 
@@ -149,7 +150,7 @@ public class StrimziKafkaClusterTest {
             .withInternalTopicReplicationFactor(3)
             .build();
 
-        assertThat(cluster.getBrokers().size(), CoreMatchers.is(5));
+        assertThat(cluster.getNodes().size(), CoreMatchers.is(5));
         assertThat(cluster.getInternalTopicReplicationFactor(), CoreMatchers.is(3));
     }
 
@@ -161,7 +162,7 @@ public class StrimziKafkaClusterTest {
             .withInternalTopicReplicationFactor(2)
             .build();
 
-        assertThat(cluster.getBrokers().size(), CoreMatchers.is(4));
+        assertThat(cluster.getNodes().size(), CoreMatchers.is(4));
         assertThat(cluster.isSharedNetworkEnabled(), CoreMatchers.is(true));
     }
 
@@ -177,11 +178,11 @@ public class StrimziKafkaClusterTest {
             .withAdditionalKafkaConfiguration(additionalConfigs)
             .build();
 
-        assertThat(cluster.getBrokers().size(), CoreMatchers.is(3));
-        assertThat(((StrimziKafkaContainer) cluster.getBrokers().iterator().next()).getKafkaVersion(), CoreMatchers.is("3.7.1"));
+        assertThat(cluster.getNodes().size(), CoreMatchers.is(3));
+        assertThat(((StrimziKafkaContainer) cluster.getNodes().iterator().next()).getKafkaVersion(), CoreMatchers.is("3.7.1"));
         assertThat(cluster.getAdditionalKafkaConfiguration().get("log.retention.bytes"), CoreMatchers.is("10485760"));
         assertThat(
-            ((StrimziKafkaContainer) cluster.getBrokers().iterator().next())
+            ((StrimziKafkaContainer) cluster.getNodes().iterator().next())
                 .getKafkaConfigurationMap()
                 .get("log.retention.bytes"),
             CoreMatchers.is("10485760")
@@ -363,5 +364,19 @@ public class StrimziKafkaClusterTest {
         assertThat(bootstrapServers, CoreMatchers.is(CoreMatchers.not(emptyString())));
         String[] servers = bootstrapServers.split(",");
         assertThat(servers.length, CoreMatchers.is(3));
+    }
+
+    @Test
+    void testGetNodesAndBrokersReturnsGenericContainers() {
+        StrimziKafkaCluster cluster = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
+            .withNumberOfBrokers(2)
+            .build();
+
+        assertThat(cluster.getBrokers().size(), CoreMatchers.is(2));
+        assertThat(cluster.getNodes().size(), CoreMatchers.is(2));
+
+        for (GenericContainer<?> container : cluster.getNodes()) {
+            assertThat(container, CoreMatchers.instanceOf(GenericContainer.class));
+        }
     }
 }


### PR DESCRIPTION
This PR renames brokers to nodes to reflect KRaft’s mixed roles and exposes GenericContainer instances via getNodes(), enabling direct access to container-level operations like port exposure and file mounting. Moreover, it deprecates our getBrokers() method and directly tells the end user to use getNodes(). 