### PR TITLE
Moved to use the Sonatype Central Portal

### DIFF
--- a/.azure/scripts/push_to_nexus.sh
+++ b/.azure/scripts/push_to_nexus.sh
@@ -14,6 +14,6 @@ export GPG_TTY=$(tty)
 echo $GPG_SIGNING_KEY | base64 -d > signing.gpg
 gpg --batch --import signing.gpg
 
-GPG_EXECUTABLE=gpg mvn $MVN_ARGS -DskipTests -s ./.azure/scripts/settings.xml -P ossrh verify deploy
+GPG_EXECUTABLE=gpg mvn $MVN_ARGS -DskipTests -s ./.azure/scripts/settings.xml -P central verify deploy
 
 cleanup

--- a/.azure/scripts/settings.xml
+++ b/.azure/scripts/settings.xml
@@ -1,9 +1,9 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
     <servers>
         <server>
-            <id>ossrh</id>
-            <username>${env.NEXUS_USERNAME}</username>
-            <password>${env.NEXUS_PASSWORD}</password>
+            <id>central</id>
+            <username>${env.CENTRAL_USERNAME}</username>
+            <password>${env.CENTRAL_PASSWORD}</password>
         </server>
     </servers>
 </settings>

--- a/.azure/templates/steps/push_artifacts.yaml
+++ b/.azure/templates/steps/push_artifacts.yaml
@@ -7,7 +7,7 @@ steps:
     env:
       GPG_PASSPHRASE: $(GPG_PASSPHRASE)
       GPG_SIGNING_KEY: $(GPG_SIGNING_KEY)
-      NEXUS_USERNAME: $(NEXUS_USERNAME)
-      NEXUS_PASSWORD: $(NEXUS_PASSWORD)
+      NEXUS_USERNAME: $(CENTRAL_USERNAME)
+      NEXUS_PASSWORD: $(CENTRAL_PASSWORD)
     displayName: "Push artifacts to Nexus repository"
     condition: and(succeeded(), or(eq(variables.isMain, true), eq(variables.isTagBranch, true)), eq(${{ parameters.JDK_VERSION }}, '17'))

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
         <maven.source-plugin.version>3.2.1</maven.source-plugin.version>
         <maven.checkstyle.version>3.5.0</maven.checkstyle.version>
         <maven.gpg.version>1.6</maven.gpg.version>
-        <sonatype.nexus.staging>1.7.0</sonatype.nexus.staging>
+        <central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
         <pit-junit-plugin.version>1.2.1</pit-junit-plugin.version>
         <pit-plugin.version>1.18.1</pit-plugin.version>
 
@@ -137,17 +137,6 @@
         <skipTests>false</skipTests>
         <skip.surefire.tests>${skipTests}</skip.surefire.tests>
     </properties>
-
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
 
     <dependencies>
         <!--  CODE DEPENDENCY  -->
@@ -464,7 +453,7 @@
 
     <profiles>
         <profile>
-            <id>ossrh</id>
+            <id>central</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
@@ -498,14 +487,12 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>${sonatype.nexus.staging}</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>${central-publishing-maven-plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                            <publishingServerId>central</publishingServerId>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
This PR addresses part of https://github.com/strimzi/test-container/issues/140, specifically the migration of artefact pushes from the OSSRH legacy system to the new Sonatype Central Publisher Portal.