### PR TITLE
Use GET /health endpoint for Connect readiness

### DIFF
--- a/src/main/java/io/strimzi/test/container/StrimziConnectCluster.java
+++ b/src/main/java/io/strimzi/test/container/StrimziConnectCluster.java
@@ -53,7 +53,7 @@ public class StrimziConnectCluster {
                     .withExposedPorts(CONNECT_PORT)
                     .withEnv("LOG_DIR", "/tmp")
                     .waitForRunning()
-                    .waitingFor(Wait.forHttp("/").forStatusCode(200));
+                    .waitingFor(Wait.forHttp("/health").forStatusCode(200));
             workers.add(worker);
         }
     }


### PR DESCRIPTION
The `GET /health` endpoint was added to the Connect REST API in Kafka 3.9.0 ([KIP-1017](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1017%3A+Health+check+endpoint+for+Kafka+Connect)) to determine if a Connect worker is healthy.

Since we now only support versions >= 3.9, switch to this endpoint instead of `GET /` for readiness.