### PR TITLE
Fixed credentials handling to push to Sonatype Central Portal

### DIFF
--- a/.azure/templates/steps/push_artifacts.yaml
+++ b/.azure/templates/steps/push_artifacts.yaml
@@ -7,7 +7,7 @@ steps:
     env:
       GPG_PASSPHRASE: $(GPG_PASSPHRASE)
       GPG_SIGNING_KEY: $(GPG_SIGNING_KEY)
-      NEXUS_USERNAME: $(CENTRAL_USERNAME)
-      NEXUS_PASSWORD: $(CENTRAL_PASSWORD)
+      CENTRAL_USERNAME: $(CENTRAL_USERNAME)
+      CENTRAL_PASSWORD: $(CENTRAL_PASSWORD)
     displayName: "Push artifacts to Nexus repository"
     condition: and(succeeded(), or(eq(variables.isMain, true), eq(variables.isTagBranch, true)), eq(${{ parameters.JDK_VERSION }}, '17'))


### PR DESCRIPTION
This PR fixes an issue about credentials for pushing artifacts to the new Central Portal.