### PR TITLE
Use our own DoNotMutate annotation and remove arc depedency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,12 +186,6 @@
             <artifactId>toxiproxy-java</artifactId>
             <version>${toxiproxy.java.version}</version>
         </dependency>
-        <!-- for mutation testing       -->
-        <dependency>
-            <groupId>com.arcmutate</groupId>
-            <artifactId>pitest-annotations</artifactId>
-            <version>${pitest-annotations.version}</version>
-        </dependency>
 
         <!-- TEST DEPENDENCY -->
         <dependency>

--- a/src/main/java/io/strimzi/test/container/DoNotMutate.java
+++ b/src/main/java/io/strimzi/test/container/DoNotMutate.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.test.container;
+
+/**
+ * Indicates that a method should be excluded from mutation testing within the test container.
+ * <p>
+ * This annotation is intended for methods that are specifically covered by integration tests
+ * and cannot be effectively tested at the unit test level.
+ * Mutation testing tools should skip mutating these annotated methods to avoid false negatives
+ * in mutation coverage reporting.
+ *
+ * <p><b>Note:</b> This annotation is <i>not</i> part of the public API and is for internal use only.</p>
+ */
+@interface DoNotMutate {
+}

--- a/src/main/java/io/strimzi/test/container/StrimziConnectCluster.java
+++ b/src/main/java/io/strimzi/test/container/StrimziConnectCluster.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.test.container;
 
-import com.groupcdg.pitest.annotations.DoNotMutate;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 

--- a/src/main/java/io/strimzi/test/container/StrimziConnectContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziConnectContainer.java
@@ -5,7 +5,6 @@
 package io.strimzi.test.container;
 
 import com.github.dockerjava.api.command.InspectContainerResponse;
-import com.groupcdg.pitest.annotations.DoNotMutate;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.images.builder.Transferable;

--- a/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.test.container;
 
-import com.groupcdg.pitest.annotations.DoNotMutate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Container;

--- a/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
@@ -6,7 +6,6 @@ package io.strimzi.test.container;
 
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.model.ContainerNetwork;
-import com.groupcdg.pitest.annotations.DoNotMutate;
 import eu.rekawek.toxiproxy.Proxy;
 import eu.rekawek.toxiproxy.ToxiproxyClient;
 import org.apache.logging.log4j.Level;


### PR DESCRIPTION
This PR removes Arcmutate dependency from our codebase, and use our own `DoNotMutate` annotation for mutation testing.