### PR TITLE
Add release pipeline

### DIFF
--- a/.azure/release-pipeline.yaml
+++ b/.azure/release-pipeline.yaml
@@ -1,0 +1,24 @@
+# Triggers
+trigger: none
+pr: none
+
+# Parameters
+parameters:
+  - name: releaseVersion
+    displayName: Release Version
+    type: string
+
+# Stages
+stages:
+  - stage: publish_artifacts
+    displayName: Publish artifacts for ${{ parameters.releaseVersion }}
+    condition: startsWith(variables['build.sourceBranch'], 'refs/heads/release-')
+    jobs:
+      - template: 'templates/steps/release_artifacts.yaml'
+        parameters:
+          artifactSource: 'current'
+          artifactProject: 'strimzi'
+          artifactPipeline: ''
+          artifactRunVersion: ''
+          artifactRunId: ''
+          releaseVersion: '${{ parameters.releaseVersion }}'

--- a/.azure/templates/steps/push_artifacts.yaml
+++ b/.azure/templates/steps/push_artifacts.yaml
@@ -10,4 +10,4 @@ steps:
       CENTRAL_USERNAME: $(CENTRAL_USERNAME)
       CENTRAL_PASSWORD: $(CENTRAL_PASSWORD)
     displayName: "Push artifacts to Nexus repository"
-    condition: and(succeeded(), or(eq(variables.isMain, true), eq(variables.isTagBranch, true)), eq(${{ parameters.JDK_VERSION }}, '17'))
+    condition: and(succeeded(), eq(variables.isMain, true), eq(${{ parameters.JDK_VERSION }}, '17'))

--- a/.azure/templates/steps/release_artifacts.yaml
+++ b/.azure/templates/steps/release_artifacts.yaml
@@ -1,0 +1,33 @@
+jobs:
+  - job: 'release_artifacts'
+    displayName: 'Prepare and release artifacts'
+    # Set timeout for jobs
+    timeoutInMinutes: 60
+    # Base system
+    pool:
+      vmImage: 'Ubuntu-22.04'
+    # Pipeline steps
+    steps:
+      # Install Prerequisites
+      - template: 'setup_java.yaml'
+
+      # Change the release version
+      - bash: "mvn versions:set -DnewVersion=$(echo $RELEASE_VERSION | tr a-z A-Z)"
+        displayName: "Configure release version to ${{ parameters.releaseVersion }}"
+        env:
+          RELEASE_VERSION: '${{ parameters.releaseVersion }}'
+
+      - bash: "mvn install -DskipTests"
+        displayName: "Build Java"
+
+      # Deploy to Central
+      - bash: "./.azure/scripts/push_to_central.sh"
+        env:
+          BUILD_REASON: $(Build.Reason)
+          BRANCH: $(Build.SourceBranch)
+          GPG_PASSPHRASE: $(GPG_PASSPHRASE)
+          GPG_SIGNING_KEY: $(GPG_SIGNING_KEY)
+          CENTRAL_USERNAME: $(CENTRAL_USERNAME)
+          CENTRAL_PASSWORD: $(CENTRAL_PASSWORD)
+          MVN_ARGS: "-e -V -B"
+        displayName: "Deploy Java artifacts"

--- a/.azure/templates/steps/setup_java.yaml
+++ b/.azure/templates/steps/setup_java.yaml
@@ -5,7 +5,7 @@ parameters:
 steps:
     - task: JavaToolInstaller@0
       inputs:
-        versionSpec: $(JDK_VERSION)
+        versionSpec: ${{ parameters.JDK_VERSION }}
         jdkArchitectureOption: 'x64'
         jdkSourceOption: 'PreInstalled'
       displayName: 'Configure Java'


### PR DESCRIPTION
This PR adds release pipeline to the `main` branch, so we have the release process in-sync with other repositories and it is also easier to specify the release version (RC or GA).