### PR TITLE
chore(deps): commons-compress to follow test container version 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,11 +128,6 @@
         <pit-junit-plugin.version>1.2.1</pit-junit-plugin.version>
         <pit-plugin.version>1.18.1</pit-plugin.version>
 
-        <!-- FIX VULNERABILITY VERSIONS  -->
-        <commons-compress.version>1.27.1</commons-compress.version>
-        <commons-codec.version>1.18.0</commons-codec.version>
-        <commons-lang3.version>3.16.0</commons-lang3.version>
-        <commons-io.version>2.16.1</commons-io.version>
         <junit4.version>4.13.2</junit4.version>
 
         <!-- properties to skip surefire tests during failsafe execution -->
@@ -245,41 +240,6 @@
             <artifactId>junit-jupiter-engine</artifactId>
             <version>${jupiter.version}</version>
             <scope>test</scope>
-        </dependency>
-
-        <!-- overriding version of commons-compress for Test container - Vulnerability -->
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-compress</artifactId>
-            <version>${commons-compress.version}</version>
-        </dependency>
-        <!-- address compatibility issues that arise
-        from upgrading `commons-compress`. Version 1.26.0 of `commons-compress` relies on functionalities provided
-        by `commons-codec` 1.16.1, leading to a requirement for this specific version of `commons-codec` to avoid
-        classpath conflicts and ensure runtime compatibility.
-        -->
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <version>${commons-codec.version}</version>
-        </dependency>
-        <!--
-          Required by commons-compress 1.27.0+ (ArrayFill class used at runtime).
-          Without this, file copy in Testcontainers fails with NoClassDefFoundError.
-        -->
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>${commons-lang3.version}</version>
-        </dependency>
-        <!--
-          Used by both commons-compress and commons-codec during stream operations.
-          Included to avoid runtime surprises in environments missing commons-io.
-        -->
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>${commons-io.version}</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Downgrade the commons-compress to 1.24.0 to follow test-container versions and avoid bumping and overriding transitive dependencies.