### PR TITLE
Add Kafka 4.1.0 and removed 3.9.x versions

### DIFF
--- a/src/main/resources/kafka_versions.json
+++ b/src/main/resources/kafka_versions.json
@@ -1,7 +1,6 @@
 {
   "kafkaVersions": {
-    "3.9.0": "quay.io/strimzi-test-container/test-container:latest-kafka-3.9.0",
-    "3.9.1": "quay.io/strimzi-test-container/test-container:latest-kafka-3.9.1",
-    "4.0.0": "quay.io/strimzi-test-container/test-container:latest-kafka-4.0.0"
+    "4.0.0": "quay.io/strimzi-test-container/test-container:latest-kafka-4.0.0",
+    "4.1.0": "quay.io/strimzi-test-container/test-container:latest-kafka-4.1.0"
   }
 }

--- a/src/test/java/io/strimzi/test/container/StrimziConnectClusterIT.java
+++ b/src/test/java/io/strimzi/test/container/StrimziConnectClusterIT.java
@@ -106,7 +106,8 @@ public class StrimziConnectClusterIT {
 
     @Test
     public void testKafkaVersion() throws Exception {
-        String version = "3.9.0";
+        // retrieve Kafka version different from latest one (if there is previous minor).
+        String version = KafkaVersionService.getInstance().previousMinor().getVersion();
         connectCluster = new StrimziConnectCluster.StrimziConnectClusterBuilder()
                 .withGroupId("my-cluster")
                 .withKafkaCluster(kafkaCluster)


### PR DESCRIPTION
This PR adds a recently released Kafka 4.1.0, and also follows the pattern of Strimzi Kafka Operator, I am removing 3.9.x versions.