### PR TITLE
Deprecate StrimziKafkaContainer

### DIFF
--- a/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
@@ -50,7 +50,12 @@ import java.util.stream.Collectors;
  * This class uses {@code getBootstrapServers()} to build the {@code KAFKA_ADVERTISED_LISTENERS} configuration.
  * When {@code proxyContainer} is configured, the bootstrap URL returned by {@code getBootstrapServers()} contains the proxy host and port.
  * For this reason, Kafka clients will always pass through the proxy, even after refreshing cluster metadata.
+ *
+ * @deprecated This class is deprecated and will be removed from the public API in version 0.114.0.
+ *             Users should migrate to using {@link StrimziKafkaCluster} instead, which provides better
+ *             multi-node support and more comprehensive cluster management capabilities.
  */
+@Deprecated
 public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContainer> implements KafkaContainer {
 
     // class attributes


### PR DESCRIPTION
This PR initiates the migration of the Strimzi Kafka Container API. The plan is to remove this class from the public API in' 0.114.0' and enforce the use of StrimziKafkaCluster for all users. Strimzi Kafka Container will still be used internally (as encapsulation of most logic within the container).

Users could easily change their testing envs by following:
```java
StrimziKafkaContainer systemUnderTest = new StrimziKafkaContainer()
systemUnderTest.start();
```
with 
```java
StrimziKafkaCluster systemUnderTest = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
       .withNumberOfBrokers(1)
       .build();
systemUnderTest.start();
```
