### PR TITLE
Add support for log collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ kafkaCluster.stop();  // Logs are automatically saved when container stops
 ```java
 StrimziKafkaCluster kafkaCluster = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
     .withNumberOfBrokers(3)
-    .withLogFilePath("/path/to/my/logs/")  // Custom directory with trailing slash
+    .withLogCollection("/path/to/my/logs/")  // Custom directory with trailing slash
     .build();
 
 kafkaCluster.start();
@@ -287,7 +287,7 @@ For combined-role clusters, each node gets a generic container log:
 ```java
 StrimziKafkaCluster kafkaCluster = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
     .withNumberOfBrokers(3)
-    .withLogFilePath("my-test-logs/")
+    .withLogCollection("my-test-logs/")
     .build();
 
 kafkaCluster.start();

--- a/README.md
+++ b/README.md
@@ -226,7 +226,86 @@ StrimziKafkaCluster kafkaCluster = new StrimziKafkaCluster.StrimziKafkaClusterBu
 kafkaCluster.start();
 ```
 
-#### xii) Logging Kafka Container/Cluster Output to SLF4J
+#### xii) Log Collection for StrimziKafkaCluster
+
+StrimziKafkaCluster supports automatic log collection from all Kafka containers. This is useful for debugging, monitoring, and analyzing the cluster behavior during tests.
+
+##### Basic log collection with default path
+
+```java
+StrimziKafkaCluster kafkaCluster = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
+    .withNumberOfBrokers(3)
+    .withLogCollection()  // Saves logs to target/strimzi-test-container-logs/
+    .build();
+
+kafkaCluster.start();
+// ... run your tests
+kafkaCluster.stop();  // Logs are automatically saved when container stops
+```
+
+##### Custom log file path
+
+```java
+StrimziKafkaCluster kafkaCluster = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
+    .withNumberOfBrokers(3)
+    .withLogFilePath("/path/to/my/logs/")  // Custom directory with trailing slash
+    .build();
+
+kafkaCluster.start();
+// ... run your tests
+kafkaCluster.stop();
+```
+
+##### Log collection with dedicated controller/broker roles
+
+When using dedicated roles, logs are automatically organized by node type:
+
+```java
+StrimziKafkaCluster kafkaCluster = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
+    .withNumberOfBrokers(2)
+    .withDedicatedRoles()
+    .withNumberOfControllers(3)
+    .withLogCollection()
+    .build();
+
+kafkaCluster.start();
+// ... run your tests
+kafkaCluster.stop();
+
+// Files created:
+// - target/strimzi-test-container-logs/kafka-controller-0.log
+// - target/strimzi-test-container-logs/kafka-controller-1.log
+// - target/strimzi-test-container-logs/kafka-controller-2.log
+// - target/strimzi-test-container-logs/kafka-broker-3.log
+// - target/strimzi-test-container-logs/kafka-broker-4.log
+```
+
+##### Log collection with combined roles (default)
+
+For combined-role clusters, each node gets a generic container log:
+
+```java
+StrimziKafkaCluster kafkaCluster = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
+    .withNumberOfBrokers(3)
+    .withLogFilePath("my-test-logs/")
+    .build();
+
+kafkaCluster.start();
+// ... run your tests
+kafkaCluster.stop();
+
+// Files created:
+// - my-test-logs/kafka-container-0.log
+// - my-test-logs/kafka-container-1.log
+// - my-test-logs/kafka-container-2.log
+```
+
+> [!NOTE]
+Log collection happens automatically when containers are stopped. 
+If a path ends with "/", role-based filenames are automatically appended. 
+Without the trailing slash, the exact path is used as the filename base.
+
+#### xiii) Logging Kafka Container/Cluster Output to SLF4J
 
 If you want to enable logging of the Kafka container’s output to SLF4J, 
 you can set the environment variable `STRIMZI_TEST_CONTAINER_LOGGING_ENABLED` to true. 

--- a/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
@@ -130,7 +130,7 @@ public class StrimziKafkaCluster implements KafkaContainer {
                     .waitForRunning();
 
                 if (this.logFilePath != null) {
-                    kafkaContainer.withLogFilePath(this.logFilePath);
+                    kafkaContainer.withLogCollection(this.logFilePath);
                 }
 
                 LOGGER.info("Started combined role node with id: {}", kafkaContainer);
@@ -158,7 +158,7 @@ public class StrimziKafkaCluster implements KafkaContainer {
                     .waitForRunning();
 
                 if (this.logFilePath != null) {
-                    controllerContainer.withLogFilePath(this.logFilePath);
+                    controllerContainer.withLogCollection(this.logFilePath);
                 }
 
                 LOGGER.info("Started controller-only node with id: {}", controllerContainer);
@@ -187,7 +187,7 @@ public class StrimziKafkaCluster implements KafkaContainer {
                     .waitForRunning();
 
                 if (this.logFilePath != null) {
-                    brokerContainer.withLogFilePath(this.logFilePath);
+                    brokerContainer.withLogCollection(this.logFilePath);
                 }
 
                 LOGGER.info("Started broker-only node with id: {}", brokerContainer);
@@ -356,7 +356,7 @@ public class StrimziKafkaCluster implements KafkaContainer {
          * @param logFilePath the base path where container logs will be saved. Use "/" suffix for automatic role-based naming.
          * @return the current instance of {@code StrimziKafkaClusterBuilder} for method chaining
          */
-        public StrimziKafkaClusterBuilder withLogFilePath(final String logFilePath) {
+        public StrimziKafkaClusterBuilder withLogCollection(final String logFilePath) {
             if (logFilePath != null && !logFilePath.trim().isEmpty()) {
                 this.logFilePath = logFilePath.trim();
             } else {

--- a/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
@@ -47,6 +47,7 @@ public class StrimziKafkaCluster implements KafkaContainer {
     private final boolean enableSharedNetwork;
     private final String kafkaVersion;
     private final boolean useDedicatedRoles;
+    private final String logFilePath;
 
     // not editable
     private final Network network;
@@ -70,6 +71,7 @@ public class StrimziKafkaCluster implements KafkaContainer {
         this.proxyContainer = builder.proxyContainer;
         this.kafkaVersion = builder.kafkaVersion;
         this.clusterId = builder.clusterId;
+        this.logFilePath = builder.logFilePath;
 
         validateBrokerNum(this.brokersNum);
         if (this.isUsingDedicatedRoles()) {
@@ -127,6 +129,10 @@ public class StrimziKafkaCluster implements KafkaContainer {
                     .withNodeRole(KafkaNodeRole.COMBINED)
                     .waitForRunning();
 
+                if (this.logFilePath != null) {
+                    kafkaContainer.withLogFilePath(this.logFilePath);
+                }
+
                 LOGGER.info("Started combined role node with id: {}", kafkaContainer);
 
                 return kafkaContainer;
@@ -150,6 +156,10 @@ public class StrimziKafkaCluster implements KafkaContainer {
                     .withClusterId(this.clusterId)
                     .withNodeRole(KafkaNodeRole.CONTROLLER)
                     .waitForRunning();
+
+                if (this.logFilePath != null) {
+                    controllerContainer.withLogFilePath(this.logFilePath);
+                }
 
                 LOGGER.info("Started controller-only node with id: {}", controllerContainer);
                 return controllerContainer;
@@ -175,6 +185,10 @@ public class StrimziKafkaCluster implements KafkaContainer {
                     .withClusterId(this.clusterId)
                     .withNodeRole(KafkaNodeRole.BROKER)
                     .waitForRunning();
+
+                if (this.logFilePath != null) {
+                    brokerContainer.withLogFilePath(this.logFilePath);
+                }
 
                 LOGGER.info("Started broker-only node with id: {}", brokerContainer);
                 return brokerContainer;
@@ -223,6 +237,7 @@ public class StrimziKafkaCluster implements KafkaContainer {
         private boolean enableSharedNetwork;
         private String kafkaVersion;
         private String clusterId;
+        private String logFilePath;
 
         /**
          * Sets the number of Kafka brokers in the cluster.
@@ -315,6 +330,38 @@ public class StrimziKafkaCluster implements KafkaContainer {
          */
         public StrimziKafkaClusterBuilder withNumberOfControllers(int controllersNum) {
             this.controllersNum = controllersNum;
+            return this;
+        }
+
+        /**
+         * Fluent method to enable log collection with a default log file path.
+         * The actual filename is determined at runtime when logs are collected.
+         *
+         * @return StrimziKafkaContainer instance for method chaining
+         */
+        public StrimziKafkaClusterBuilder withLogCollection() {
+            this.logFilePath = "target/strimzi-test-container-logs/";
+            return this;
+        }
+
+        /**
+         * Fluent method to enable log collection for all containers in the cluster with a custom log file path.
+         *
+         * If the path ends with "/", role-based filenames are automatically appended at runtime for each container:
+         *      Controller-only: "kafka-controller-{nodeId}.log"
+         *      Broker-only: "kafka-broker-{brokerId}.log"
+         *      Combined: "kafka-container-{brokerId}.log"
+         * otherwise,  the path doesn't end with "/", it's used as the exact filename base for all containers
+         *
+         * @param logFilePath the base path where container logs will be saved. Use "/" suffix for automatic role-based naming.
+         * @return the current instance of {@code StrimziKafkaClusterBuilder} for method chaining
+         */
+        public StrimziKafkaClusterBuilder withLogFilePath(final String logFilePath) {
+            if (logFilePath != null && !logFilePath.trim().isEmpty()) {
+                this.logFilePath = logFilePath.trim();
+            } else {
+                throw new IllegalArgumentException("Log file path cannot be null or empty.");
+            }
             return this;
         }
 

--- a/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
@@ -1051,7 +1051,7 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
      * @param logFilePath the base path where container logs will be saved. Use "/" suffix for automatic role-based naming.
      * @return the current instance of {@code StrimziKafkaClusterBuilder} for method chaining
      */
-    public StrimziKafkaContainer withLogFilePath(final String logFilePath) {
+    public StrimziKafkaContainer withLogCollection(final String logFilePath) {
         if (logFilePath != null && !logFilePath.trim().isEmpty()) {
             this.logFilePath = logFilePath.trim();
         } else {

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaClusterIT.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaClusterIT.java
@@ -429,7 +429,7 @@ public class StrimziKafkaClusterIT extends AbstractIT {
 
         this.systemUnderTest = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
             .withNumberOfBrokers(1)
-            .withLogFilePath("test-cluster-logs/")
+            .withLogCollection("test-cluster-logs/")
             .build();
 
         this.systemUnderTest.start();

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaClusterTest.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaClusterTest.java
@@ -605,8 +605,71 @@ public class StrimziKafkaClusterTest {
         String bootstrapControllers = cluster.getBootstrapControllers();
         assertThat(bootstrapControllers, is(CoreMatchers.notNullValue()));
         assertThat(bootstrapControllers, is(CoreMatchers.not(emptyString())));
-        
+
         String[] controllers = bootstrapControllers.split(",");
         assertThat(controllers.length, is(1));
+    }
+
+    @Test
+    void testWithLogCollection() {
+        StrimziKafkaCluster cluster = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
+            .withNumberOfBrokers(3)
+            .withLogCollection()
+            .build();
+
+        assertThat(cluster, is(CoreMatchers.notNullValue()));
+    }
+
+    @Test
+    void testWithLogFilePathValid() {
+        assertDoesNotThrow(() ->
+            new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
+                .withNumberOfBrokers(3)
+                .withLogFilePath("target/test-logs/")
+                .build()
+        );
+    }
+
+    @Test
+    void testWithLogFilePathNullThrowsException() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+            new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
+                .withNumberOfBrokers(3)
+                .withLogFilePath(null)
+                .build()
+        );
+        assertThat(exception.getMessage(), CoreMatchers.containsString("Log file path cannot be null or empty"));
+    }
+
+    @Test
+    void testWithLogFilePathEmptyThrowsException() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+            new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
+                .withNumberOfBrokers(3)
+                .withLogFilePath("")
+                .build()
+        );
+        assertThat(exception.getMessage(), CoreMatchers.containsString("Log file path cannot be null or empty"));
+    }
+
+    @Test
+    void testWithLogFilePathWhitespaceOnlyThrowsException() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+            new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
+                .withNumberOfBrokers(3)
+                .withLogFilePath("   ")
+                .build()
+        );
+        assertThat(exception.getMessage(), CoreMatchers.containsString("Log file path cannot be null or empty"));
+    }
+
+    @Test
+    void testWithLogFilePathTrimsWhitespace() {
+        assertDoesNotThrow(() ->
+            new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
+                .withNumberOfBrokers(3)
+                .withLogFilePath("  target/test-logs/  ")
+                .build()
+        );
     }
 }

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaClusterTest.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaClusterTest.java
@@ -625,7 +625,7 @@ public class StrimziKafkaClusterTest {
         assertDoesNotThrow(() ->
             new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
                 .withNumberOfBrokers(3)
-                .withLogFilePath("target/test-logs/")
+                .withLogCollection("target/test-logs/")
                 .build()
         );
     }
@@ -635,7 +635,7 @@ public class StrimziKafkaClusterTest {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
             new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
                 .withNumberOfBrokers(3)
-                .withLogFilePath(null)
+                .withLogCollection(null)
                 .build()
         );
         assertThat(exception.getMessage(), CoreMatchers.containsString("Log file path cannot be null or empty"));
@@ -646,7 +646,7 @@ public class StrimziKafkaClusterTest {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
             new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
                 .withNumberOfBrokers(3)
-                .withLogFilePath("")
+                .withLogCollection("")
                 .build()
         );
         assertThat(exception.getMessage(), CoreMatchers.containsString("Log file path cannot be null or empty"));
@@ -657,7 +657,7 @@ public class StrimziKafkaClusterTest {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
             new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
                 .withNumberOfBrokers(3)
-                .withLogFilePath("   ")
+                .withLogCollection("   ")
                 .build()
         );
         assertThat(exception.getMessage(), CoreMatchers.containsString("Log file path cannot be null or empty"));
@@ -668,7 +668,7 @@ public class StrimziKafkaClusterTest {
         assertDoesNotThrow(() ->
             new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
                 .withNumberOfBrokers(3)
-                .withLogFilePath("  target/test-logs/  ")
+                .withLogCollection("  target/test-logs/  ")
                 .build()
         );
     }
@@ -679,7 +679,7 @@ public class StrimziKafkaClusterTest {
             .withNumberOfBrokers(2)
             .withDedicatedRoles()
             .withNumberOfControllers(2)
-            .withLogFilePath("target/dedicated-roles-logs/")
+            .withLogCollection("target/dedicated-roles-logs/")
             .build();
 
         assertThat(cluster.isUsingDedicatedRoles(), is(true));

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaClusterTest.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaClusterTest.java
@@ -672,4 +672,19 @@ public class StrimziKafkaClusterTest {
                 .build()
         );
     }
+
+    @Test
+    void testDedicatedRolesClusterWithLogFilePath() {
+        StrimziKafkaCluster cluster = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
+            .withNumberOfBrokers(2)
+            .withDedicatedRoles()
+            .withNumberOfControllers(2)
+            .withLogFilePath("target/dedicated-roles-logs/")
+            .build();
+
+        assertThat(cluster.isUsingDedicatedRoles(), is(true));
+        assertThat(cluster.getControllers().size(), is(2));
+        assertThat(cluster.getBrokers().size(), is(2));
+        assertThat(cluster.getNodes().size(), is(4));
+    }
 }

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaContainerIT.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaContainerIT.java
@@ -219,7 +219,7 @@ public class StrimziKafkaContainerIT extends AbstractIT {
 
         systemUnderTest = new StrimziKafkaContainer()
             .withBrokerId(1)
-            .withLogFilePath(customLogPath)
+            .withLogCollection(customLogPath)
             .waitForRunning();
 
         systemUnderTest.start();

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaContainerTest.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaContainerTest.java
@@ -27,6 +27,7 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -874,5 +875,46 @@ class StrimziKafkaContainerTest {
         );
 
         assertThat(exception.getMessage(), containsString("Broker-only nodes do not provide controller endpoints"));
+    }
+
+    @Test
+    void testWithLogCollection() {
+        StrimziKafkaContainer result = kafkaContainer.withLogCollection();
+        assertSame(kafkaContainer, result, "withLogCollection() should return the same instance for method chaining.");
+    }
+
+    @Test
+    void testWithLogFilePathValid() {
+        StrimziKafkaContainer result = kafkaContainer.withLogFilePath("target/test-logs/");
+        assertSame(kafkaContainer, result, "withLogFilePath() should return the same instance for method chaining.");
+    }
+
+    @Test
+    void testWithLogFilePathNullThrowsException() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+            kafkaContainer.withLogFilePath(null)
+        );
+        assertThat(exception.getMessage(), containsString("Log file path cannot be null or empty"));
+    }
+
+    @Test
+    void testWithLogFilePathEmptyThrowsException() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+            kafkaContainer.withLogFilePath("")
+        );
+        assertThat(exception.getMessage(), containsString("Log file path cannot be null or empty"));
+    }
+
+    @Test
+    void testWithLogFilePathWhitespaceOnlyThrowsException() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+            kafkaContainer.withLogFilePath("   ")
+        );
+        assertThat(exception.getMessage(), containsString("Log file path cannot be null or empty"));
+    }
+
+    @Test
+    void testWithLogFilePathTrimsWhitespace() {
+        assertDoesNotThrow(() -> kafkaContainer.withLogFilePath("  target/test-logs/  "));
     }
 }

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaContainerTest.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaContainerTest.java
@@ -885,14 +885,14 @@ class StrimziKafkaContainerTest {
 
     @Test
     void testWithLogFilePathValid() {
-        StrimziKafkaContainer result = kafkaContainer.withLogFilePath("target/test-logs/");
+        StrimziKafkaContainer result = kafkaContainer.withLogCollection("target/test-logs/");
         assertSame(kafkaContainer, result, "withLogFilePath() should return the same instance for method chaining.");
     }
 
     @Test
     void testWithLogFilePathNullThrowsException() {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-            kafkaContainer.withLogFilePath(null)
+            kafkaContainer.withLogCollection(null)
         );
         assertThat(exception.getMessage(), containsString("Log file path cannot be null or empty"));
     }
@@ -900,7 +900,7 @@ class StrimziKafkaContainerTest {
     @Test
     void testWithLogFilePathEmptyThrowsException() {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-            kafkaContainer.withLogFilePath("")
+            kafkaContainer.withLogCollection("")
         );
         assertThat(exception.getMessage(), containsString("Log file path cannot be null or empty"));
     }
@@ -908,13 +908,13 @@ class StrimziKafkaContainerTest {
     @Test
     void testWithLogFilePathWhitespaceOnlyThrowsException() {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-            kafkaContainer.withLogFilePath("   ")
+            kafkaContainer.withLogCollection("   ")
         );
         assertThat(exception.getMessage(), containsString("Log file path cannot be null or empty"));
     }
 
     @Test
     void testWithLogFilePathTrimsWhitespace() {
-        assertDoesNotThrow(() -> kafkaContainer.withLogFilePath("  target/test-logs/  "));
+        assertDoesNotThrow(() -> kafkaContainer.withLogCollection("  target/test-logs/  "));
     }
 }


### PR DESCRIPTION
This PR solves [1]. Currently, we can modify stdout logs altogether. However, in some cases, it's better to store logs for each container in a separate file.

[1] - https://github.com/strimzi/test-container/issues/119