### PR TITLE
Minor Java cleanups:

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Since the Docker image is a simple encapsulation of Kafka binaries, you can spin
 Therefore, it is a suitable candidate for the unit or integration testing. If you need something more complex, there is a multi-node Kafka cluster implementation with only infrastructure limitations.
 The most important classes are described here:
 - `StrimziKafkaContainer` is a single-node instance of Kafka using the image from quay.io/strimzi-test-container/test-container with the given version.
-  You can use in KRaft mode [KIP-500](https://github.com/apache/kafka/blob/trunk/config/kraft/README.md), which allows running Apache Kafka without Apache ZooKeeper.
 
   Additional configuration for Kafka brokers can be injected through methods such as withKafkaConfigurationMap.
   This container is a good fit for integration testing, but for more comprehensive testing, we suggest using StrimziKafkaCluster.

--- a/src/main/java/io/strimzi/test/container/KafkaVersionService.java
+++ b/src/main/java/io/strimzi/test/container/KafkaVersionService.java
@@ -221,13 +221,15 @@ class KafkaVersionService {
      * On a later date it might return 2.7.3.
      * It is allowed to cross major version boundaries.
      * E.g. the previous minor release to 3.0.0 might be 2.8.2
+     * <pre>
      * ============================================================
      * | (prev prev minor) ---  (previous minor) ---  (current) |
-     *                                                     |
-     *                                                     *
-     * |    2.8.1   &lt;---&gt;     2.8.2  &lt;---&gt;   3.0.0  |
+     *                                                          |
+     * |      2.8.1       &lt;---&gt;        2.8.2    &lt;---&gt;   3.0.0   |
      * ============================================================
+     * </pre>
      * Assuming that test container images `kafka_versions.yaml` has the following content:
+     * <pre>
      * {
      *   "version": 1,
      *   "kafkaVersions": {
@@ -236,6 +238,7 @@ class KafkaVersionService {
      *     "3.0.0": "test-container:latest-kafka-3.0.0"
      *   }
      * }
+     * </pre>
      * @return LogicalKafkaVersion the previous minor release
      */
     public KafkaVersion previousMinor() {

--- a/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
@@ -30,8 +30,7 @@ import java.util.stream.Stream;
 
 /**
  * A multi-node instance of Kafka using the latest image from quay.io/strimzi/kafka with the given version.
- * It perfectly fits for integration/system testing. The additional configuration for Kafka brokers can be passed to the constructor.
- * <br><br>
+ * It perfectly fits for integration/system testing.
  */
 public class StrimziKafkaCluster implements KafkaContainer {
 
@@ -56,7 +55,6 @@ public class StrimziKafkaCluster implements KafkaContainer {
     private Collection<KafkaContainer> brokers;
     private final String clusterId;
 
-    @SuppressWarnings("deprecation")
     private StrimziKafkaCluster(StrimziKafkaClusterBuilder builder) {
         this.brokersNum = builder.brokersNum;
         this.controllersNum = builder.controllersNum;
@@ -86,7 +84,6 @@ public class StrimziKafkaCluster implements KafkaContainer {
         prepareKafkaCluster(this.additionalKafkaConfiguration, this.kafkaVersion);
     }
 
-    @SuppressWarnings("deprecation")
     private void prepareKafkaCluster(final Map<String, String> additionalKafkaConfiguration, final String kafkaVersion) {
         final Map<String, String> defaultKafkaConfigurationForMultiNode = new HashMap<>();
         defaultKafkaConfigurationForMultiNode.put("offsets.topic.replication.factor", String.valueOf(internalTopicReplicationFactor));

--- a/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
@@ -29,10 +29,8 @@ import java.nio.file.Paths;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -47,8 +45,7 @@ import java.util.stream.Collectors;
 
 /**
  * StrimziKafkaContainer is a single-node instance of Kafka using the image from quay.io/strimzi/kafka with the
- * given version. This container runs Kafka in KRaft mode (without ZooKeeper) and is suitable for basic
- * integration testing but for more hardcore testing we suggest using {@link StrimziKafkaCluster}.
+ * given version.
  * <br><br>
  * Optionally, you can configure a {@code proxyContainer} to simulate network conditions (i.e. connection cut, latency).
  * This class uses {@code getBootstrapServers()} to build the {@code KAFKA_ADVERTISED_LISTENERS} configuration.
@@ -155,7 +152,7 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
         // instances and by default each container has its own network.
         super.setNetwork(Network.SHARED);
         // Initially expose Kafka port - will be updated in doStart() based on node role
-        super.setExposedPorts(Collections.singletonList(KAFKA_PORT));
+        super.setExposedPorts(List.of(KAFKA_PORT));
         super.addEnv("LOG_DIR", "/tmp");
     }
 
@@ -178,13 +175,13 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
 
         if (this.nodeRole == KafkaNodeRole.CONTROLLER) {
             // Controller-only nodes expose the controller
-            super.setExposedPorts(Collections.singletonList(CONTROLLER_PORT));
+            super.setExposedPorts(List.of(CONTROLLER_PORT));
         } else if (this.nodeRole == KafkaNodeRole.BROKER) {
             // Broker-only nodes expose the Kafka client port
-            super.setExposedPorts(Collections.singletonList(KAFKA_PORT));
+            super.setExposedPorts(List.of(KAFKA_PORT));
         } else {
             // Combined-role nodes expose both client and controller ports
-            super.setExposedPorts(Arrays.asList(KAFKA_PORT, CONTROLLER_PORT));
+            super.setExposedPorts(List.of(KAFKA_PORT, CONTROLLER_PORT));
         }
 
         // Setup network alias
@@ -890,7 +887,7 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
     public StrimziKafkaContainer withProxyContainer(final ToxiproxyContainer proxyContainer) {
         if (proxyContainer != null) {
             this.proxyContainer = proxyContainer;
-            proxyContainer.setNetworkAliases(Collections.singletonList("toxiproxy"));
+            proxyContainer.setNetworkAliases(List.of("toxiproxy"));
         }
         return self();
     }

--- a/src/test/java/io/strimzi/test/container/AbstractIT.java
+++ b/src/test/java/io/strimzi/test/container/AbstractIT.java
@@ -12,14 +12,10 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.params.provider.Arguments;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.JsonNode;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
 public class AbstractIT {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractIT.class);
 
     /**
      * Provides {@code parameters} for each {@link org.junit.jupiter.params.ParameterizedTest}.

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaClusterTest.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaClusterTest.java
@@ -367,7 +367,6 @@ public class StrimziKafkaClusterTest {
         assertThat(servers.length, is(3));
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     void testGetNodesAndBrokersReturnsGenericContainers() {
         StrimziKafkaCluster cluster = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaContainerTest.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaContainerTest.java
@@ -15,7 +15,6 @@ import org.testcontainers.utility.MountableFile;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.util.Base64;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
@@ -237,7 +236,7 @@ class StrimziKafkaContainerTest {
         defaultProperties.setProperty("key1", "value1");
         defaultProperties.setProperty("key2", "value2");
 
-        String result = kafkaContainer.overrideProperties(defaultProperties, Collections.emptyMap());
+        String result = kafkaContainer.overrideProperties(defaultProperties, Map.of());
 
         assertThat("Result should contain key1=value1", result, containsString("key1=value1"));
         assertThat("Result should contain key2=value2", result, containsString("key2=value2"));
@@ -356,9 +355,6 @@ class StrimziKafkaContainerTest {
         assertThat(properties.getProperty("node.id"), is("1"));
         assertThat(properties.getProperty("controller.quorum.voters"), is("1@broker-1:9094"));
         assertThat(properties.getProperty("controller.listener.names"), is("CONTROLLER"));
-
-        // zookeeper.connect should not be set
-        assertThat("zookeeper.connect should not be set when useKraft is true", properties.getProperty("zookeeper.connect"), nullValue());
     }
 
     @Test


### PR DESCRIPTION
- Use Admin instead of AdminClient
- Use Map.of/List.of instead of Collections/Arrays
- Use constants for Kafka client configs
- Remove ZooKeeper mentions
- Clean some Javadoc