### PR TITLE
Bump main branch to 0.114.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>io.strimzi</groupId>
     <artifactId>strimzi-test-container</artifactId>
     <packaging>jar</packaging>
-    <version>0.113.0-SNAPSHOT</version>
+    <version>0.114.0-SNAPSHOT</version>
 
     <licenses>
         <license>


### PR DESCRIPTION
This PR bumps the main branch to use `0.114.0-SNAPSHOT`.