### PR TITLE
Remove StrimziKafkaContainer from public API and enforces to use Strim…

### DIFF
--- a/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
@@ -105,7 +105,6 @@ public class StrimziKafkaCluster implements KafkaContainer {
         }
     }
 
-    @SuppressWarnings("deprecation")
     private void prepareCombinedRolesCluster(final Map<String, String> kafkaConfiguration, final String kafkaVersion) {
         // multi-node set up with combined roles
         this.nodes = IntStream
@@ -137,7 +136,6 @@ public class StrimziKafkaCluster implements KafkaContainer {
             .collect(Collectors.toList());
     }
 
-    @SuppressWarnings("deprecation")
     private void prepareDedicatedRolesCluster(final Map<String, String> kafkaConfiguration, final String kafkaVersion) {
         // Create controller nodes - they get the first set of IDs
         this.controllers = IntStream
@@ -391,7 +389,6 @@ public class StrimziKafkaCluster implements KafkaContainer {
      * Get the bootstrap servers that containers on the same network should use to connect
      * @return a comma separated list of Kafka bootstrap servers
      */
-    @SuppressWarnings("deprecation")
     @DoNotMutate
     public String getNetworkBootstrapServers() {
         return getBrokers().stream()
@@ -421,7 +418,6 @@ public class StrimziKafkaCluster implements KafkaContainer {
      * Get the bootstrap controllers that containers on the same network should use to connect to controllers
      * @return a comma separated list of Kafka controller endpoints
      */
-    @SuppressWarnings("deprecation")
     @DoNotMutate
     public String getNetworkBootstrapControllers() {
         return getControllers().stream()
@@ -441,7 +437,6 @@ public class StrimziKafkaCluster implements KafkaContainer {
         return this.additionalKafkaConfiguration;
     }
 
-    @SuppressWarnings("deprecation")
     private void configureQuorumVoters(final Map<String, String> additionalKafkaConfiguration) {
         final String quorumVoters;
         
@@ -481,7 +476,6 @@ public class StrimziKafkaCluster implements KafkaContainer {
             this::checkAllBrokersReady);
     }
 
-    @SuppressWarnings("deprecation")
     @DoNotMutate
     private boolean checkAllBrokersReady() {
         try {
@@ -500,7 +494,6 @@ public class StrimziKafkaCluster implements KafkaContainer {
         }
     }
 
-    @SuppressWarnings("deprecation")
     @DoNotMutate
     private boolean isBrokerReady(StrimziKafkaContainer kafkaContainer) throws IOException, InterruptedException {
         Container.ExecResult result = kafkaContainer.execInContainer(

--- a/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
@@ -51,13 +51,8 @@ import java.util.stream.Collectors;
  * This class uses {@code getBootstrapServers()} to build the {@code KAFKA_ADVERTISED_LISTENERS} configuration.
  * When {@code proxyContainer} is configured, the bootstrap URL returned by {@code getBootstrapServers()} contains the proxy host and port.
  * For this reason, Kafka clients will always pass through the proxy, even after refreshing cluster metadata.
- *
- * @deprecated This class is deprecated and will be removed from the public API in version 0.114.0.
- *             Users should migrate to using {@link StrimziKafkaCluster} instead, which provides better
- *             multi-node support and more comprehensive cluster management capabilities.
  */
-@Deprecated
-public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContainer> implements KafkaContainer {
+class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContainer> implements KafkaContainer {
 
     // class attributes
     private static final Logger LOGGER = LoggerFactory.getLogger(StrimziKafkaContainer.class);


### PR DESCRIPTION
…ziKafkaCluster

This PR removes `StrimziKafkaContainer` from the public API and enforces to use of StrimziKafkaCluster.