### PR TITLE
Update to Testcontainers 2.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,23 +96,22 @@
         <maven.compiler.release>11</maven.compiler.release>
 
         <!-- DEPENDENCY CODE VERSIONS       -->
-        <test-containers.version>1.21.0</test-containers.version>
+        <test-containers.version>2.0.2</test-containers.version>
         <spotbugs.version>4.9.3</spotbugs.version>
         <log4j.version>2.19.0</log4j.version>
-        <docker-java.version>3.5.0</docker-java.version>
+        <docker-java.version>3.7.0</docker-java.version>
         <kafka.version>4.0.0</kafka.version>
         <slf4j.version>1.7.36</slf4j.version>
         <fasterxml.jackson-core.version>2.19.0</fasterxml.jackson-core.version>
         <fasterxml.jackson-databind.version>2.19.0</fasterxml.jackson-databind.version>
-        <toxiproxy.java.version>2.1.7</toxiproxy.java.version>
+        <toxiproxy.java.version>2.1.11</toxiproxy.java.version>
         <pitest-annotations.version>2.2.1</pitest-annotations.version>
 
         <!-- DEPENDENCY TEST VERSIONS      -->
         <jupiter.version>5.11.4</jupiter.version>
         <hamcrest.version>2.2</hamcrest.version>
         <maven-surefire-failsafe-plugin.version>3.1.2</maven-surefire-failsafe-plugin.version>
-        <!-- for Java 11 compatibility (newer versions does not support Java 11)  -->
-        <testcontainers-keycloak.version>2.6.0</testcontainers-keycloak.version>
+        <testcontainers-keycloak.version>4.0.0</testcontainers-keycloak.version>
         <fasterxml.jackson-annotations.version>2.16.2</fasterxml.jackson-annotations.version>
         <kafka-oauth-client.version>0.16.2</kafka-oauth-client.version>
         <mockito.version>5.17.0</mockito.version>
@@ -144,7 +143,7 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>toxiproxy</artifactId>
+            <artifactId>testcontainers-toxiproxy</artifactId>
             <version>${test-containers.version}</version>
         </dependency>
         <dependency>

--- a/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
@@ -10,7 +10,7 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.ToxiproxyContainer;
+import org.testcontainers.toxiproxy.ToxiproxyContainer;
 import org.testcontainers.lifecycle.Startables;
 
 import java.io.IOException;

--- a/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
@@ -13,7 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.ToxiproxyContainer;
+import org.testcontainers.toxiproxy.ToxiproxyContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.containers.wait.strategy.WaitStrategy;

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaClusterIT.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaClusterIT.java
@@ -27,7 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.ToxiproxyContainer;
+import org.testcontainers.toxiproxy.ToxiproxyContainer;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaClusterTest.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaClusterTest.java
@@ -9,7 +9,8 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.ToxiproxyContainer;
+import org.testcontainers.toxiproxy.ToxiproxyContainer;
+import org.testcontainers.utility.DockerImageName;
 
 import java.util.HashMap;
 import java.util.List;
@@ -22,6 +23,8 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class StrimziKafkaClusterTest {
+
+    private static final DockerImageName TOXIPROXY_DOCKER_IMAGE_NAME = DockerImageName.parse("shopify/toxiproxy");
 
     @Test
     void testKafkaClusterNegativeOrZeroNumberOfNodes() {
@@ -79,7 +82,7 @@ public class StrimziKafkaClusterTest {
 
     @Test
     void testKafkaClusterWithProxyContainer() {
-        ToxiproxyContainer proxyContainer = new ToxiproxyContainer();
+        ToxiproxyContainer proxyContainer = new ToxiproxyContainer(TOXIPROXY_DOCKER_IMAGE_NAME);
         assertDoesNotThrow(() ->
             new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
                 .withNumberOfBrokers(3)
@@ -91,7 +94,7 @@ public class StrimziKafkaClusterTest {
 
     @Test
     void testKafkaClusterWithProxyContainerConfiguresProxyPorts() {
-        ToxiproxyContainer proxyContainer = new ToxiproxyContainer();
+        ToxiproxyContainer proxyContainer = new ToxiproxyContainer(TOXIPROXY_DOCKER_IMAGE_NAME);
 
         StrimziKafkaCluster cluster = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
             .withNumberOfBrokers(3)
@@ -111,7 +114,7 @@ public class StrimziKafkaClusterTest {
 
     @Test
     void testKafkaClusterWithProxyContainerAndDedicatedRolesConfiguresProxyPorts() {
-        ToxiproxyContainer proxyContainer = new ToxiproxyContainer();
+        ToxiproxyContainer proxyContainer = new ToxiproxyContainer(TOXIPROXY_DOCKER_IMAGE_NAME);
 
         StrimziKafkaCluster cluster = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
             .withNumberOfBrokers(2)
@@ -134,7 +137,7 @@ public class StrimziKafkaClusterTest {
 
     @Test
     void testKafkaClusterWithProxyContainerSingleBrokerConfiguresProxyPorts() {
-        ToxiproxyContainer proxyContainer = new ToxiproxyContainer();
+        ToxiproxyContainer proxyContainer = new ToxiproxyContainer(TOXIPROXY_DOCKER_IMAGE_NAME);
 
         StrimziKafkaCluster cluster = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
             .withNumberOfBrokers(1)
@@ -151,7 +154,7 @@ public class StrimziKafkaClusterTest {
 
     @Test
     void testKafkaClusterWithProxyContainerDedicatedRolesMinimumConfiguresProxyPorts() {
-        ToxiproxyContainer proxyContainer = new ToxiproxyContainer();
+        ToxiproxyContainer proxyContainer = new ToxiproxyContainer(TOXIPROXY_DOCKER_IMAGE_NAME);
 
         StrimziKafkaCluster cluster = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
             .withNumberOfBrokers(1)
@@ -171,7 +174,7 @@ public class StrimziKafkaClusterTest {
 
     @Test
     void testKafkaClusterWithProxyContainerAndKafkaClusterSetSameNetwork() {
-        ToxiproxyContainer proxyContainer = new ToxiproxyContainer();
+        ToxiproxyContainer proxyContainer = new ToxiproxyContainer(TOXIPROXY_DOCKER_IMAGE_NAME);
 
         assertThat(proxyContainer.getNetwork(), CoreMatchers.nullValue());
 

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaContainerMockTest.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaContainerMockTest.java
@@ -11,7 +11,7 @@ import eu.rekawek.toxiproxy.Proxy;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.testcontainers.containers.ToxiproxyContainer;
+import org.testcontainers.toxiproxy.ToxiproxyContainer;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaContainerTest.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaContainerTest.java
@@ -9,7 +9,8 @@ import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.ToxiproxyContainer;
+import org.testcontainers.toxiproxy.ToxiproxyContainer;
+import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
 import java.lang.reflect.Method;
@@ -32,6 +33,8 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class StrimziKafkaContainerTest {
+
+    private static final DockerImageName TOXIPROXY_DOCKER_IMAGE_NAME = DockerImageName.parse("shopify/toxiproxy");
 
     private StrimziKafkaContainer kafkaContainer;
 
@@ -85,7 +88,7 @@ class StrimziKafkaContainerTest {
 
     @Test
     void testBootstrapServersWithProxy() {
-        ToxiproxyContainer proxyContainer = new ToxiproxyContainer();
+        ToxiproxyContainer proxyContainer = new ToxiproxyContainer(TOXIPROXY_DOCKER_IMAGE_NAME);
         StrimziKafkaContainer kafkaContainer = new StrimziKafkaContainer()
             .withProxyContainer(proxyContainer);
 
@@ -762,7 +765,7 @@ class StrimziKafkaContainerTest {
 
     @Test
     void testWithProxyContainerSetsNetworkAliases() {
-        ToxiproxyContainer proxyContainer = new ToxiproxyContainer();
+        ToxiproxyContainer proxyContainer = new ToxiproxyContainer(TOXIPROXY_DOCKER_IMAGE_NAME);
         kafkaContainer.withProxyContainer(proxyContainer);
         
         assertThat(proxyContainer.getNetworkAliases(), hasItem("toxiproxy"));


### PR DESCRIPTION
This PR updates to Testcontainers 2.0.2, Toxiproxy-java 2.1.11 and Docker Java 3.7.0.

Note that the existing jars somehow worked with Testcontainers 1.x but better be ready for when they remove the deprecated classes.