### PR TITLE
Make the StrimziKafkaContainer class public without any public constructor

### DIFF
--- a/src/main/java/io/strimzi/test/container/KafkaNodeRole.java
+++ b/src/main/java/io/strimzi/test/container/KafkaNodeRole.java
@@ -7,7 +7,7 @@ package io.strimzi.test.container;
 /**
  * Internal: Enum representing the different roles a Kafka node can have in KRaft mode.
  */
-enum KafkaNodeRole {
+public enum KafkaNodeRole {
     /**
      * Combined node that acts as both broker and controller.
      * This is the default behavior and maintains backward compatibility.

--- a/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
@@ -51,7 +51,7 @@ import java.util.stream.Collectors;
  * When {@code proxyContainer} is configured, the bootstrap URL returned by {@code getBootstrapServers()} contains the proxy host and port.
  * For this reason, Kafka clients will always pass through the proxy, even after refreshing cluster metadata.
  */
-class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContainer> implements KafkaContainer {
+public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContainer> implements KafkaContainer {
 
     // class attributes
     private static final Logger LOGGER = LoggerFactory.getLogger(StrimziKafkaContainer.class);
@@ -132,7 +132,7 @@ class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContainer> impl
     /**
      * Image name is specified lazily automatically in {@link #doStart()} method
      */
-    public StrimziKafkaContainer() {
+    StrimziKafkaContainer() {
         this(new CompletableFuture<>());
     }
 
@@ -141,7 +141,7 @@ class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContainer> impl
      *
      * @param dockerImageName specific docker image name provided by constructor parameter
      */
-    public StrimziKafkaContainer(String dockerImageName) {
+    StrimziKafkaContainer(String dockerImageName) {
         this(CompletableFuture.completedFuture(dockerImageName));
     }
 
@@ -1088,7 +1088,7 @@ class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContainer> impl
         return this.kafkaVersion;
     }
 
-    /* test */ int getNodeId() {
+    public int getNodeId() {
         return nodeId;
     }
 

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaClusterIT.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaClusterIT.java
@@ -120,8 +120,8 @@ public class StrimziKafkaClusterIT extends AbstractIT {
 
         systemUnderTest.start();
         List<String> bootstrapUrls = new ArrayList<>();
-        for (KafkaContainer kafkaContainer : systemUnderTest.getBrokers()) {
-            Proxy proxy = ((StrimziKafkaContainer) kafkaContainer).getProxy();
+        for (StrimziKafkaContainer kafkaContainer : systemUnderTest.getBrokers()) {
+            Proxy proxy = kafkaContainer.getProxy();
             assertThat(proxy, notNullValue());
             bootstrapUrls.add(kafkaContainer.getBootstrapServers());
         }
@@ -467,7 +467,7 @@ public class StrimziKafkaClusterIT extends AbstractIT {
 
         this.systemUnderTest.start();
 
-        StrimziKafkaContainer container = (StrimziKafkaContainer) systemUnderTest.getBrokers().iterator().next();
+        StrimziKafkaContainer container = systemUnderTest.getBrokers().iterator().next();
         List<Integer> exposedPorts = container.getExposedPorts();
 
         assertThat("Combined role should expose KAFKA_PORT", exposedPorts.contains(StrimziKafkaContainer.KAFKA_PORT), is(true));
@@ -485,14 +485,14 @@ public class StrimziKafkaClusterIT extends AbstractIT {
 
         this.systemUnderTest.start();
 
-        StrimziKafkaContainer broker = (StrimziKafkaContainer) systemUnderTest.getBrokers().iterator().next();
+        StrimziKafkaContainer broker = systemUnderTest.getBrokers().iterator().next();
         List<Integer> brokerPorts = broker.getExposedPorts();
 
         assertThat("Broker should expose KAFKA_PORT", brokerPorts.contains(StrimziKafkaContainer.KAFKA_PORT), is(true));
         assertThat("Broker should not expose CONTROLLER_PORT", brokerPorts.contains(StrimziKafkaContainer.CONTROLLER_PORT), is(false));
         assertThat(broker.getNodeRole(), is(KafkaNodeRole.BROKER));
 
-        StrimziKafkaContainer controller = (StrimziKafkaContainer) systemUnderTest.getControllers().iterator().next();
+        StrimziKafkaContainer controller = systemUnderTest.getControllers().iterator().next();
         List<Integer> controllerPorts = controller.getExposedPorts();
 
         assertThat("Controller should expose CONTROLLER_PORT", controllerPorts.contains(StrimziKafkaContainer.CONTROLLER_PORT), is(true));
@@ -512,7 +512,7 @@ public class StrimziKafkaClusterIT extends AbstractIT {
 
         this.systemUnderTest.start();
 
-        StrimziKafkaContainer container = (StrimziKafkaContainer) systemUnderTest.getBrokers().iterator().next();
+        StrimziKafkaContainer container = systemUnderTest.getBrokers().iterator().next();
         List<Integer> exposedPorts = container.getExposedPorts();
 
         assertThat("Should expose KAFKA_PORT", exposedPorts.contains(StrimziKafkaContainer.KAFKA_PORT), is(true));
@@ -535,7 +535,7 @@ public class StrimziKafkaClusterIT extends AbstractIT {
 
         this.systemUnderTest.start();
 
-        StrimziKafkaContainer broker = (StrimziKafkaContainer) systemUnderTest.getBrokers().iterator().next();
+        StrimziKafkaContainer broker = systemUnderTest.getBrokers().iterator().next();
         List<Integer> brokerPorts = broker.getExposedPorts();
 
         assertThat("Broker should expose KAFKA_PORT", brokerPorts.contains(StrimziKafkaContainer.KAFKA_PORT), is(true));
@@ -544,7 +544,7 @@ public class StrimziKafkaClusterIT extends AbstractIT {
         assertThat("Should expose custom port 8081", brokerPorts.contains(8081), is(true));
         assertThat(broker.getNodeRole(), is(KafkaNodeRole.BROKER));
 
-        StrimziKafkaContainer controller = (StrimziKafkaContainer) systemUnderTest.getControllers().iterator().next();
+        StrimziKafkaContainer controller = systemUnderTest.getControllers().iterator().next();
         List<Integer> controllerPorts = controller.getExposedPorts();
 
         assertThat("Controller should expose CONTROLLER_PORT", controllerPorts.contains(StrimziKafkaContainer.CONTROLLER_PORT), is(true));
@@ -796,8 +796,7 @@ public class StrimziKafkaClusterIT extends AbstractIT {
             this.systemUnderTest.start();
 
             // Verify all brokers have successfully logged in
-            for (KafkaContainer broker : this.systemUnderTest.getBrokers()) {
-                StrimziKafkaContainer container = (StrimziKafkaContainer) broker;
+            for (StrimziKafkaContainer container : this.systemUnderTest.getBrokers()) {
                 assertThat(container.getLogs(), CoreMatchers.containsString("Successfully logged in."));
                 assertThat(container.getLogs(), CoreMatchers.containsString("JWKS keys change detected. Keys updated."));
             }


### PR DESCRIPTION
StrimziKafkaCluster now returns StrimziKafkaContainer as nodes, and has a withContainerCustomizer builder method to enable customization

Resolves #175 