### PR TITLE
Refactor input validation by introducing requireNonBlank utility method

### DIFF
--- a/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
@@ -493,11 +493,7 @@ public class StrimziKafkaCluster implements KafkaContainer {
          * @throws IllegalArgumentException if the image name is null or empty
          */
         public StrimziKafkaClusterBuilder withImage(String kafkaImage) {
-            if (kafkaImage != null && !kafkaImage.trim().isEmpty()) {
-                this.kafkaImage = kafkaImage.trim();
-            } else {
-                throw new IllegalArgumentException("Kafka image cannot be null or empty.");
-            }
+            this.kafkaImage = Utils.requireNonBlank(kafkaImage, "Kafka image");
             return this;
         }
 
@@ -548,11 +544,7 @@ public class StrimziKafkaCluster implements KafkaContainer {
          * @return the current instance of {@code StrimziKafkaClusterBuilder} for method chaining
          */
         public StrimziKafkaClusterBuilder withLogCollection(final String logFilePath) {
-            if (logFilePath != null && !logFilePath.trim().isEmpty()) {
-                this.logFilePath = logFilePath.trim();
-            } else {
-                throw new IllegalArgumentException("Log file path cannot be null or empty.");
-            }
+            this.logFilePath = Utils.requireNonBlank(logFilePath, "Log file path");
             return this;
         }
 
@@ -649,11 +641,7 @@ public class StrimziKafkaCluster implements KafkaContainer {
          * @throws IllegalArgumentException if the username is null or empty
          */
         public StrimziKafkaClusterBuilder withSaslUsername(String saslUsername) {
-            if (saslUsername != null && !saslUsername.trim().isEmpty()) {
-                this.saslUsername = saslUsername;
-            } else {
-                throw new IllegalArgumentException("SASL username cannot be null or empty.");
-            }
+            this.saslUsername = Utils.requireNonBlank(saslUsername, "SASL username");
             return this;
         }
 
@@ -665,11 +653,7 @@ public class StrimziKafkaCluster implements KafkaContainer {
          * @throws IllegalArgumentException if the password is null or empty
          */
         public StrimziKafkaClusterBuilder withSaslPassword(String saslPassword) {
-            if (saslPassword != null && !saslPassword.trim().isEmpty()) {
-                this.saslPassword = saslPassword;
-            } else {
-                throw new IllegalArgumentException("SASL password cannot be null or empty.");
-            }
+            this.saslPassword = Utils.requireNonBlank(saslPassword, "SASL password");
             return this;
         }
 

--- a/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
@@ -1080,11 +1080,7 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
      * @return StrimziKafkaContainer instance for method chaining.
      */
     public StrimziKafkaContainer withSaslUsername(String saslUsername) {
-        if (saslUsername != null && !saslUsername.trim().isEmpty()) {
-            this.saslUsername = saslUsername;
-        } else {
-            throw new IllegalArgumentException("SASL username cannot be null or empty.");
-        }
+        this.saslUsername = Utils.requireNonBlank(saslUsername, "SASL username");
         return self();
     }
 
@@ -1095,11 +1091,7 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
      * @return StrimziKafkaContainer instance for method chaining.
      */
     public StrimziKafkaContainer withSaslPassword(String saslPassword) {
-        if (saslPassword != null && !saslPassword.trim().isEmpty()) {
-            this.saslPassword = saslPassword;
-        } else {
-            throw new IllegalArgumentException("SASL password cannot be null or empty.");
-        }
+        this.saslPassword = Utils.requireNonBlank(saslPassword, "SASL password");
         return self();
     }
 
@@ -1208,11 +1200,7 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
      * @return the current instance of {@code StrimziKafkaClusterBuilder} for method chaining
      */
     public StrimziKafkaContainer withLogCollection(final String logFilePath) {
-        if (logFilePath != null && !logFilePath.trim().isEmpty()) {
-            this.logFilePath = logFilePath.trim();
-        } else {
-            throw new IllegalArgumentException("Log file path cannot be null or empty.");
-        }
+        this.logFilePath = Utils.requireNonBlank(logFilePath, "Log file path");
         return self();
     }
 

--- a/src/main/java/io/strimzi/test/container/Utils.java
+++ b/src/main/java/io/strimzi/test/container/Utils.java
@@ -126,4 +126,20 @@ class Utils {
             throw new UncheckedIOException("Failed to find free port", e);
         }
     }
+
+    /**
+     * Checks that the given string is not null, empty, or only whitespace. 
+     * If it is, an IllegalArgumentException is thrown with a message 
+     * containing the field name.
+     * 
+     * @param value the string to check
+     * @param fieldName the name of the field being checked, used in the exception message
+     * @return the trimmed string if it is valid
+     */
+    static String requireNonBlank(String value, String fieldName) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(fieldName + " cannot be null or empty.");
+        }
+        return value.trim();
+    }
 }


### PR DESCRIPTION
Fixed #203,

Extract repeated non-blank string validation into a utility method

Affected methods                                                                                   

  - StrimziKafkaCluster.StrimziKafkaClusterBuilder#withImage
  - StrimziKafkaCluster.StrimziKafkaClusterBuilder#withLogCollection
  - StrimziKafkaCluster.StrimziKafkaClusterBuilder#withSaslUsername
  - StrimziKafkaCluster.StrimziKafkaClusterBuilder#withSaslPassword
  - StrimziKafkaContainer#withLogCollection
  - StrimziKafkaContainer#withSaslUsername
  - StrimziKafkaContainer#withSaslPassword