### PR TITLE
Fix controller advertised.listeners to use network aliases in dedicated-roles KRaft clusters

### DIFF
--- a/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
@@ -124,8 +124,10 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
         CLIENT,
         /** Inter-broker communication listener */
         INTER_BROKER,
-        /** Controller communication listener */
-        CONTROLLER
+        /** Controller communication listener (internal, Docker network) */
+        CONTROLLER,
+        /** Controller communication listener (external, host-accessible) */
+        CONTROLLER_EXTERNAL
     }
 
     /**
@@ -575,7 +577,7 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
             advertisedListeners.append(",");
             advertisedListeners.append(getBootstrapControllers());
             kafkaListeners.append(",").append("CONTROLLER_EXTERNAL").append("://0.0.0.0:").append(StrimziKafkaContainer.CONTROLLER_EXTERNAL_PORT);
-            this.listeners.add(new ListenerConfig("CONTROLLER_EXTERNAL", ListenerRole.CONTROLLER));
+            this.listeners.add(new ListenerConfig("CONTROLLER_EXTERNAL", ListenerRole.CONTROLLER_EXTERNAL));
         }
     }
 

--- a/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
@@ -857,13 +857,17 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
      */
     private String ensureControllerMapping(String securityProtocolMap, String controllerProtocol) {
         String result = (securityProtocolMap == null) ? "" : securityProtocolMap.trim();
-        if (!result.contains("CONTROLLER:")) {
-            result = result.isEmpty() ? "CONTROLLER:" + controllerProtocol : result + ",CONTROLLER:" + controllerProtocol;
+
+        final String[] requiredMappings = (this.nodeRole == KafkaNodeRole.CONTROLLER)
+            ? new String[]{"CONTROLLER:", "CONTROLLER_EXTERNAL:"}
+            : new String[]{"CONTROLLER:"};
+
+        for (final String prefix : requiredMappings) {
+            if (!result.contains(prefix)) {
+                result = result.isEmpty() ? prefix + controllerProtocol : result + "," + prefix + controllerProtocol;
+            }
         }
-        // Controller-only nodes also need CONTROLLER_EXTERNAL mapping
-        if (this.nodeRole == KafkaNodeRole.CONTROLLER && !result.contains("CONTROLLER_EXTERNAL:")) {
-            result = result + ",CONTROLLER_EXTERNAL:" + controllerProtocol;
-        }
+
         return result;
     }
 

--- a/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
@@ -522,7 +522,7 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
         // Only add controller listener for nodes that act as controllers
         if (this.nodeRole.isController()) {
             advertisedListeners.append(",");
-            advertisedListeners.append(getBootstrapControllers());
+            advertisedListeners.append(getNetworkBootstrapControllers());
             final String controllerListenerName = "CONTROLLER";
             // adding Controller listener for Kraft mode
             kafkaListeners.append(controllerListenerName).append("://0.0.0.0:").append(StrimziKafkaContainer.CONTROLLER_PORT);
@@ -898,7 +898,7 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
             final int listenPort = TOXIPROXY_PORT_BASE + this.nodeId;
             return String.format("PLAINTEXT://%s:%d", TOXIPROXY_NETWORK_ALIAS, listenPort);
         }
-        return NETWORK_ALIAS_PREFIX + nodeId + ":" + INTER_BROKER_LISTENER_PORT;
+        return String.format("PLAINTEXT://%s%d:%d", NETWORK_ALIAS_PREFIX, nodeId, INTER_BROKER_LISTENER_PORT);
     }
 
     /**
@@ -944,7 +944,7 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
             final int listenPort = TOXIPROXY_PORT_BASE + this.nodeId;
             return String.format("CONTROLLER://%s:%d", TOXIPROXY_NETWORK_ALIAS, listenPort);
         }
-        return NETWORK_ALIAS_PREFIX + nodeId + ":" + StrimziKafkaContainer.CONTROLLER_PORT;
+        return String.format("CONTROLLER://%s%d:%d", NETWORK_ALIAS_PREFIX, nodeId, StrimziKafkaContainer.CONTROLLER_PORT);
     }
 
     /**

--- a/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java
@@ -30,6 +30,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
@@ -70,6 +71,11 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
      * Default Kafka controller port
      */
     public static final int CONTROLLER_PORT = 9094;
+
+    /**
+     * Default Kafka controller external port (for host-accessible controller connections)
+     */
+    public static final int CONTROLLER_EXTERNAL_PORT = 9095;
 
     /**
      * Prefix for network aliases.
@@ -235,8 +241,9 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
         // Determine default ports based on node role
         List<Integer> portsToExpose = new ArrayList<>();
         if (this.nodeRole == KafkaNodeRole.CONTROLLER) {
-            // Controller-only nodes expose the controller
-            portsToExpose.add(CONTROLLER_PORT);
+            // Controller-only nodes only need the external controller port exposed to the host.
+            // The internal CONTROLLER port (9094) is accessed via Docker network aliases.
+            portsToExpose.add(CONTROLLER_EXTERNAL_PORT);
         } else if (this.nodeRole == KafkaNodeRole.BROKER) {
             // Broker-only nodes expose the Kafka client port
             portsToExpose.add(KAFKA_PORT);
@@ -380,7 +387,13 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
         }
 
         if (this.nodeRole.isController()) {
-            this.controllerExposedPort = getMappedPort(CONTROLLER_PORT);
+            if (this.nodeRole == KafkaNodeRole.CONTROLLER) {
+                // Controller-only: external access uses CONTROLLER_EXTERNAL_PORT
+                this.controllerExposedPort = getMappedPort(CONTROLLER_EXTERNAL_PORT);
+            } else {
+                // Combined-mode: external access uses CONTROLLER_PORT (no CONTROLLER_EXTERNAL)
+                this.controllerExposedPort = getMappedPort(CONTROLLER_PORT);
+            }
             LOGGER.info("Mapped controller port: {}", controllerExposedPort);
         }
 
@@ -520,14 +533,7 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
         }
 
         // Only add controller listener for nodes that act as controllers
-        if (this.nodeRole.isController()) {
-            advertisedListeners.append(",");
-            advertisedListeners.append(getNetworkBootstrapControllers());
-            final String controllerListenerName = "CONTROLLER";
-            // adding Controller listener for Kraft mode
-            kafkaListeners.append(controllerListenerName).append("://0.0.0.0:").append(StrimziKafkaContainer.CONTROLLER_PORT);
-            this.listeners.add(new ListenerConfig(controllerListenerName, ListenerRole.CONTROLLER));
-        }
+        addControllerListeners(kafkaListeners, advertisedListeners);
 
         LOGGER.info("This is all advertised listeners for Kafka {}", advertisedListeners);
 
@@ -540,6 +546,37 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
             listeners,
             advertisedListeners.toString()
         };
+    }
+
+    /**
+     * Adds controller listeners for controller nodes.
+     * Controller-only nodes get both CONTROLLER (internal) and CONTROLLER_EXTERNAL (host-accessible) listeners.
+     * Combined-mode nodes only get the CONTROLLER listener.
+     *
+     * @param kafkaListeners StringBuilder for listeners configuration
+     * @param advertisedListeners StringBuilder for advertised.listeners configuration
+     */
+    private void addControllerListeners(StringBuilder kafkaListeners, StringBuilder advertisedListeners) {
+        if (!this.nodeRole.isController()) {
+            return;
+        }
+
+        // Internal controller listener (Docker network alias) -- all controller nodes
+        if (advertisedListeners.length() > 0) {
+            advertisedListeners.append(",");
+        }
+        advertisedListeners.append(getNetworkBootstrapControllers());
+        kafkaListeners.append("CONTROLLER").append("://0.0.0.0:").append(StrimziKafkaContainer.CONTROLLER_PORT);
+        this.listeners.add(new ListenerConfig("CONTROLLER", ListenerRole.CONTROLLER));
+
+        // External controller listener -- controller-only nodes only
+        // (Kafka forbids controller listeners in advertised.listeners for combined-mode nodes)
+        if (this.nodeRole == KafkaNodeRole.CONTROLLER) {
+            advertisedListeners.append(",");
+            advertisedListeners.append(getBootstrapControllers());
+            kafkaListeners.append(",").append("CONTROLLER_EXTERNAL").append("://0.0.0.0:").append(StrimziKafkaContainer.CONTROLLER_EXTERNAL_PORT);
+            this.listeners.add(new ListenerConfig("CONTROLLER_EXTERNAL", ListenerRole.CONTROLLER));
+        }
     }
 
     /**
@@ -603,14 +640,16 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
     }
 
     /* test */ void extractControllerListener(Properties properties, String advertisedListeners) {
-        if (advertisedListeners != null && advertisedListeners.contains("CONTROLLER://")) {
-            String[] parts = advertisedListeners.split(",");
-            for (String part : parts) {
-                if (part.trim().startsWith("CONTROLLER://")) {
-                    properties.setProperty("advertised.listeners", part.trim());
-                    break;
-                }
-            }
+        if (advertisedListeners == null || advertisedListeners.isEmpty()) {
+            return;
+        }
+        String[] parts = advertisedListeners.split(",");
+        String controllerListeners = Arrays.stream(parts)
+            .map(String::trim)
+            .filter(p -> p.startsWith("CONTROLLER://") || p.startsWith("CONTROLLER_EXTERNAL://"))
+            .collect(Collectors.joining(","));
+        if (!controllerListeners.isEmpty()) {
+            properties.setProperty("advertised.listeners", controllerListeners);
         }
     }
 
@@ -634,8 +673,13 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
         properties.setProperty("process.roles", this.nodeRole.getProcessRoles());
         properties.setProperty("node.id", String.valueOf(this.nodeId));
 
-        // Required on ALL nodes (broker-only too)
-        properties.setProperty("controller.listener.names", "CONTROLLER");
+        // Controller-only nodes have dual controller listeners (CONTROLLER + CONTROLLER_EXTERNAL)
+        // Combined and broker-only nodes use only CONTROLLER
+        if (this.nodeRole == KafkaNodeRole.CONTROLLER) {
+            properties.setProperty("controller.listener.names", "CONTROLLER,CONTROLLER_EXTERNAL");
+        } else {
+            properties.setProperty("controller.listener.names", "CONTROLLER");
+        }
 
         // For standalone containers (not part of a cluster), set default quorum voters
         if (this.kafkaConfigurationMap == null || !this.kafkaConfigurationMap.containsKey("controller.quorum.voters")) {
@@ -810,11 +854,15 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
      * @return securityProtocolMapWithControllerMapping string including CONTROLLER mapping
      */
     private String ensureControllerMapping(String securityProtocolMap, String controllerProtocol) {
-        String securityProtocolMapWithControllerMapping = (securityProtocolMap == null) ? "" : securityProtocolMap.trim();
-        if (securityProtocolMapWithControllerMapping.contains("CONTROLLER:")) {
-            return securityProtocolMapWithControllerMapping;
+        String result = (securityProtocolMap == null) ? "" : securityProtocolMap.trim();
+        if (!result.contains("CONTROLLER:")) {
+            result = result.isEmpty() ? "CONTROLLER:" + controllerProtocol : result + ",CONTROLLER:" + controllerProtocol;
         }
-        return securityProtocolMapWithControllerMapping.isEmpty() ? "CONTROLLER:" + controllerProtocol : securityProtocolMapWithControllerMapping + ",CONTROLLER:" + controllerProtocol;
+        // Controller-only nodes also need CONTROLLER_EXTERNAL mapping
+        if (this.nodeRole == KafkaNodeRole.CONTROLLER && !result.contains("CONTROLLER_EXTERNAL:")) {
+            result = result + ",CONTROLLER_EXTERNAL:" + controllerProtocol;
+        }
+        return result;
     }
 
     /**
@@ -917,14 +965,18 @@ public class StrimziKafkaContainer extends GenericContainer<StrimziKafkaContaine
             throw new UnsupportedOperationException("Broker-only nodes do not provide controller endpoints. Use controller or combined-role nodes for controller connections.");
         }
 
+        // Controller-only nodes use CONTROLLER_EXTERNAL listener name (external access)
+        // Combined-mode nodes keep CONTROLLER listener name
+        final String listenerName = (this.nodeRole == KafkaNodeRole.CONTROLLER) ? "CONTROLLER_EXTERNAL" : "CONTROLLER";
+
         if (proxyContainer != null) {
             initializeProxy();
             // Return the host-accessible proxy address
             final int listenPort = TOXIPROXY_PORT_BASE + this.nodeId;
             final int mappedPort = proxyContainer.getMappedPort(listenPort);
-            return String.format("CONTROLLER://%s:%d", proxyContainer.getHost(), mappedPort);
+            return String.format("%s://%s:%d", listenerName, proxyContainer.getHost(), mappedPort);
         }
-        return String.format("CONTROLLER://%s:%d", getHost(), this.controllerExposedPort);
+        return String.format("%s://%s:%d", listenerName, getHost(), this.controllerExposedPort);
     }
 
     /**

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaClusterIT.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaClusterIT.java
@@ -547,13 +547,16 @@ public class StrimziKafkaClusterIT extends AbstractIT {
 
         assertThat("Broker should expose KAFKA_PORT", brokerPorts.contains(StrimziKafkaContainer.KAFKA_PORT), is(true));
         assertThat("Broker should not expose CONTROLLER_PORT", brokerPorts.contains(StrimziKafkaContainer.CONTROLLER_PORT), is(false));
+        assertThat("Broker should not expose CONTROLLER_EXTERNAL_PORT", brokerPorts.contains(StrimziKafkaContainer.CONTROLLER_EXTERNAL_PORT), is(false));
         assertThat(broker.getNodeRole(), is(KafkaNodeRole.BROKER));
 
         StrimziKafkaContainer controller = systemUnderTest.getControllers().iterator().next();
         List<Integer> controllerPorts = controller.getExposedPorts();
 
-        assertThat("Controller should expose CONTROLLER_PORT", controllerPorts.contains(StrimziKafkaContainer.CONTROLLER_PORT), is(true));
+        assertThat("Controller should expose CONTROLLER_EXTERNAL_PORT", controllerPorts.contains(StrimziKafkaContainer.CONTROLLER_EXTERNAL_PORT), is(true));
+        assertThat("Controller should not expose CONTROLLER_PORT", controllerPorts.contains(StrimziKafkaContainer.CONTROLLER_PORT), is(false));
         assertThat("Controller should not expose KAFKA_PORT", controllerPorts.contains(StrimziKafkaContainer.KAFKA_PORT), is(false));
+
         assertThat(controller.getNodeRole(), is(KafkaNodeRole.CONTROLLER));
     }
 
@@ -604,7 +607,8 @@ public class StrimziKafkaClusterIT extends AbstractIT {
         StrimziKafkaContainer controller = systemUnderTest.getControllers().iterator().next();
         List<Integer> controllerPorts = controller.getExposedPorts();
 
-        assertThat("Controller should expose CONTROLLER_PORT", controllerPorts.contains(StrimziKafkaContainer.CONTROLLER_PORT), is(true));
+        assertThat("Controller should expose CONTROLLER_EXTERNAL_PORT", controllerPorts.contains(StrimziKafkaContainer.CONTROLLER_EXTERNAL_PORT), is(true));
+        assertThat("Controller should not expose CONTROLLER_PORT", controllerPorts.contains(StrimziKafkaContainer.CONTROLLER_PORT), is(false));
         assertThat("Controller should not expose KAFKA_PORT", controllerPorts.contains(StrimziKafkaContainer.KAFKA_PORT), is(false));
         assertThat("Should expose custom port 8080", controllerPorts.contains(8080), is(true));
         assertThat("Should expose custom port 8081", controllerPorts.contains(8081), is(true));

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaClusterIT.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaClusterIT.java
@@ -352,7 +352,7 @@ public class StrimziKafkaClusterIT extends AbstractIT {
         assertThat(controllers.length, is(3));
 
         for (String controller : controllers) {
-            assertThat(controller, matchesPattern("broker-[0-9]+:9094"));
+            assertThat(controller, matchesPattern("CONTROLLER://broker-[0-9]+:9094"));
         }
     }
 

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaClusterIT.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaClusterIT.java
@@ -197,6 +197,61 @@ public class StrimziKafkaClusterIT extends AbstractIT {
         }
     }
 
+    @Test
+    void testDedicatedRolesBrokerReconnectsToControllerAfterRestart() throws ExecutionException, InterruptedException, TimeoutException {
+        try (StrimziKafkaCluster cluster = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
+            .withNumberOfBrokers(3)
+            .withDedicatedRoles()
+            .withNumberOfControllers(3)
+            .build()) {
+
+            cluster.start();
+
+            this.systemUnderTest = cluster;
+            verifyFunctionalityOfKafkaCluster();
+
+            // Pick a broker to restart
+            StrimziKafkaContainer brokerToRestart = cluster.getBrokers().iterator().next();
+            int restartedNodeId = brokerToRestart.getNodeId();
+            LOGGER.info("Stopping broker with nodeId={}", restartedNodeId);
+
+            // Stop the broker container (i.e., simulate crash)
+            brokerToRestart.stop();
+
+            LOGGER.info("Restarting broker with nodeId={}", restartedNodeId);
+
+            // Restart the broker (i.e., it must reconnect to controllers using the controllers advertised.listeners
+            // (network alias, not localhost)
+            brokerToRestart.start();
+
+            // Wait for the broker to rejoin the cluster
+            try (Admin adminClient = Admin.create(Map.of(
+                AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.getBootstrapServers(),
+                AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, "30000",
+                AdminClientConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, "60000"))) {
+
+                Utils.waitFor("All brokers are available after restart",
+                    Duration.ofSeconds(5), Duration.ofMinutes(2),
+                    () -> {
+                        try {
+                            Collection<Node> brokers = adminClient.describeCluster().nodes().get(10, TimeUnit.SECONDS);
+                            LOGGER.info("Available brokers: {}", brokers.size());
+                            return brokers.size() == 3;
+                        } catch (Exception e) {
+                            LOGGER.warn("Failed to describe cluster: {}", e.getMessage());
+                            return false;
+                        }
+                    });
+            }
+
+            // Verify cluster is still functional after broker restart
+            // Use a different topic name because verifyFunctionalityOfKafkaCluster()
+            verifyFunctionalityOfKafkaClusterWithTopic("reconnect-test-topic");
+
+            LOGGER.info("Broker with nodeId={} successfully reconnected to controllers", restartedNodeId);
+        }
+    }
+
     private void setUpKafkaKRaftCluster() {
         systemUnderTest = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
             .withNumberOfBrokers(NUMBER_OF_REPLICAS)
@@ -222,6 +277,10 @@ public class StrimziKafkaClusterIT extends AbstractIT {
     }
 
     private void verifyFunctionalityOfKafkaCluster() throws ExecutionException, InterruptedException, TimeoutException {
+        verifyFunctionalityOfKafkaClusterWithTopic("example-topic");
+    }
+
+    private void verifyFunctionalityOfKafkaClusterWithTopic(String topicName) throws ExecutionException, InterruptedException, TimeoutException {
         try (final Admin adminClient = Admin.create(Map.of(
             AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, systemUnderTest.getBootstrapServers()));
              KafkaProducer<String, String> producer = new KafkaProducer<>(
@@ -242,7 +301,6 @@ public class StrimziKafkaClusterIT extends AbstractIT {
                  new StringDeserializer()
              )
         ) {
-            final String topicName = "example-topic";
             final String recordKey = "strimzi";
             final String recordValue = "the-best-project-in-the-world";
 

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaContainerMockTest.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaContainerMockTest.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -662,6 +664,43 @@ public class StrimziKafkaContainerMockTest {
         assertThat(kafkaContainer.listeners.size(), is(2));
         assertTrue(kafkaContainer.listeners.stream().anyMatch(l -> l.name().equals("CONTROLLER")));
         assertTrue(kafkaContainer.listeners.stream().anyMatch(l -> l.name().equals("CONTROLLER_EXTERNAL")));
+    }
+
+    @Test
+    void testBuildListenersConfigCombinedNodeDoesNotHaveControllerExternal() {
+        InspectContainerResponse containerInfo = Mockito.mock(InspectContainerResponse.class);
+        NetworkSettings networkSettings = Mockito.mock(NetworkSettings.class);
+        Mockito.when(containerInfo.getNetworkSettings()).thenReturn(networkSettings);
+
+        Map<String, ContainerNetwork> networks = new LinkedHashMap<>();
+        ContainerNetwork containerNetwork = Mockito.mock(ContainerNetwork.class);
+        networks.put("bridge", containerNetwork);
+        Mockito.when(networkSettings.getNetworks()).thenReturn(networks);
+
+        kafkaContainer = new StrimziKafkaContainer() {
+            @Override
+            public String getBootstrapServers() {
+                return "PLAINTEXT://localhost:9092";
+            }
+            @Override
+            public String getNetworkBootstrapControllers() {
+                return "CONTROLLER://broker-1:9094";
+            }
+        };
+        kafkaContainer.withNodeId(1)
+            .withNodeRole(KafkaNodeRole.COMBINED);
+
+        String[] listenersConfig = kafkaContainer.buildListenersConfig(containerInfo);
+
+        // Combined nodes should have CONTROLLER but NOT CONTROLLER_EXTERNAL because
+        // Kafka forbids controller listeners in advertised.listeners when process.roles contains broker
+        assertThat(listenersConfig[0], containsString("CONTROLLER://"));
+        assertThat(listenersConfig[0], not(containsString("CONTROLLER_EXTERNAL://")));
+        assertThat(listenersConfig[1], not(containsString("CONTROLLER_EXTERNAL://")));
+
+        // Verify listeners list contains CONTROLLER only, no CONTROLLER_EXTERNAL
+        assertTrue(kafkaContainer.listeners.stream().anyMatch(l -> l.name().equals("CONTROLLER")));
+        assertFalse(kafkaContainer.listeners.stream().anyMatch(l -> l.name().equals("CONTROLLER_EXTERNAL")));
     }
 
     @BeforeEach

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaContainerMockTest.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaContainerMockTest.java
@@ -53,8 +53,8 @@ public class StrimziKafkaContainerMockTest {
             }
 
             @Override
-            public String getBootstrapControllers() {
-                return "CONTROLLER://localhost:9094";
+            public String getNetworkBootstrapControllers() {
+                return "CONTROLLER://broker-0:9094";
             }
         };
 
@@ -64,7 +64,7 @@ public class StrimziKafkaContainerMockTest {
             .buildListenersConfig(containerInfo);
 
         String expectedListeners = "PLAINTEXT://0.0.0.0:9092,BROKER1://0.0.0.0:9091,CONTROLLER://0.0.0.0:9094";
-        String expectedAdvertisedListeners = "PLAINTEXT://localhost:9092,BROKER1://broker-0:9091,CONTROLLER://localhost:9094";
+        String expectedAdvertisedListeners = "PLAINTEXT://localhost:9092,BROKER1://broker-0:9091,CONTROLLER://broker-0:9094";
 
         assertThat(listenersConfig[0], is(expectedListeners));
         assertThat(listenersConfig[1], is(expectedAdvertisedListeners));
@@ -92,15 +92,15 @@ public class StrimziKafkaContainerMockTest {
             }
 
             @Override
-            public String getBootstrapControllers() {
-                return "CONTROLLER://localhost:9094";
+            public String getNetworkBootstrapControllers() {
+                return "CONTROLLER://broker-0:9094";
             }
         };
 
         String[] listenersConfig = kafkaContainer.withNodeId(0).buildListenersConfig(containerInfo);
 
         String expectedListeners = "PLAINTEXT://0.0.0.0:9092,BROKER1://0.0.0.0:9091,CONTROLLER://0.0.0.0:9094";
-        String expectedAdvertisedListeners = "PLAINTEXT://localhost:9092,BROKER1://broker-0:9091,CONTROLLER://localhost:9094";
+        String expectedAdvertisedListeners = "PLAINTEXT://localhost:9092,BROKER1://broker-0:9091,CONTROLLER://broker-0:9094";
 
         assertThat(listenersConfig[0], is(expectedListeners));
         assertThat(listenersConfig[1], is(expectedAdvertisedListeners));
@@ -131,15 +131,15 @@ public class StrimziKafkaContainerMockTest {
             }
 
             @Override
-            public String getBootstrapControllers() {
-                return "CONTROLLER://localhost:9094";
+            public String getNetworkBootstrapControllers() {
+                return "CONTROLLER://broker-0:9094";
             }
         };
 
         String[] listenersConfig = kafkaContainer.withNodeId(0).buildListenersConfig(containerInfo);
 
         String expectedListeners = "PLAINTEXT://0.0.0.0:9092,BROKER1://0.0.0.0:9091,BROKER2://0.0.0.0:9090,CONTROLLER://0.0.0.0:9094";
-        String expectedAdvertisedListeners = "PLAINTEXT://localhost:9092,BROKER1://broker-0:9091,BROKER2://broker-0:9090,CONTROLLER://localhost:9094";
+        String expectedAdvertisedListeners = "PLAINTEXT://localhost:9092,BROKER1://broker-0:9091,BROKER2://broker-0:9090,CONTROLLER://broker-0:9094";
 
         assertThat(listenersConfig[0], is(expectedListeners));
         assertThat(listenersConfig[1], is(expectedAdvertisedListeners));
@@ -167,15 +167,15 @@ public class StrimziKafkaContainerMockTest {
             }
 
             @Override
-            public String getBootstrapControllers() {
-                return "CONTROLLER://localhost:9094";
+            public String getNetworkBootstrapControllers() {
+                return "CONTROLLER://broker-0:9094";
             }
         };
 
         String[] listenersConfig = kafkaContainer.withNodeId(0).buildListenersConfig(containerInfo);
 
         String expectedListeners = "PLAINTEXT://0.0.0.0:9092,BROKER1://0.0.0.0:9091,CONTROLLER://0.0.0.0:9094";
-        String expectedAdvertisedListeners = "PLAINTEXT://localhost:9092,BROKER1://broker-0:9091,CONTROLLER://localhost:9094";
+        String expectedAdvertisedListeners = "PLAINTEXT://localhost:9092,BROKER1://broker-0:9091,CONTROLLER://broker-0:9094";
 
         assertThat(listenersConfig[0], is(expectedListeners));
         assertThat(listenersConfig[1], is(expectedAdvertisedListeners));
@@ -206,15 +206,15 @@ public class StrimziKafkaContainerMockTest {
             }
 
             @Override
-            public String getBootstrapControllers() {
-                return "CONTROLLER://localhost:9094";
+            public String getNetworkBootstrapControllers() {
+                return "CONTROLLER://broker-0:9094";
             }
         };
 
         String[] listenersConfig = kafkaContainer.withNodeId(0).buildListenersConfig(containerInfo);
 
         String expectedListeners = "PLAINTEXT://0.0.0.0:9092,BROKER1://0.0.0.0:9091,CONTROLLER://0.0.0.0:9094";
-        String expectedAdvertisedListeners = "PLAINTEXT://localhost:9092,BROKER1://broker-0:9091,CONTROLLER://localhost:9094";
+        String expectedAdvertisedListeners = "PLAINTEXT://localhost:9092,BROKER1://broker-0:9091,CONTROLLER://broker-0:9094";
 
         assertThat(listenersConfig[0], is(expectedListeners));
         assertThat(listenersConfig[1], is(expectedAdvertisedListeners));
@@ -242,15 +242,15 @@ public class StrimziKafkaContainerMockTest {
             }
 
             @Override
-            public String getBootstrapControllers() {
-                return "CONTROLLER://localhost:9094";
+            public String getNetworkBootstrapControllers() {
+                return "CONTROLLER://broker-0:9094";
             }
         };
 
-        String[] listenersConfig = kafkaContainer.buildListenersConfig(containerInfo);
+        String[] listenersConfig = kafkaContainer.withNodeId(0).buildListenersConfig(containerInfo);
 
         String expectedListeners = "PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9094";
-        String expectedAdvertisedListeners = "PLAINTEXT://localhost:9092,CONTROLLER://localhost:9094";
+        String expectedAdvertisedListeners = "PLAINTEXT://localhost:9092,CONTROLLER://broker-0:9094";
 
         assertThat(listenersConfig[0], is(expectedListeners));
         assertThat(listenersConfig[1], is(expectedAdvertisedListeners));
@@ -278,15 +278,15 @@ public class StrimziKafkaContainerMockTest {
             }
 
             @Override
-            public String getBootstrapControllers() {
-                return "CONTROLLER://localhost:9094";
+            public String getNetworkBootstrapControllers() {
+                return "CONTROLLER://broker-0:9094";
             }
         };
 
         String[] listenersConfig = kafkaContainer.withNodeId(0).buildListenersConfig(containerInfo);
 
         String expectedListeners = "SSL://0.0.0.0:9092,BROKER1://0.0.0.0:9091,CONTROLLER://0.0.0.0:9094";
-        String expectedAdvertisedListeners = "SSL://localhost:9093,BROKER1://broker-0:9091,CONTROLLER://localhost:9094";
+        String expectedAdvertisedListeners = "SSL://localhost:9093,BROKER1://broker-0:9091,CONTROLLER://broker-0:9094";
 
         assertThat(listenersConfig[0], is(expectedListeners));
         assertThat(listenersConfig[1], is(expectedAdvertisedListeners));
@@ -354,8 +354,8 @@ public class StrimziKafkaContainerMockTest {
             }
 
             @Override
-            public String getBootstrapControllers() {
-                return "CONTROLLER://localhost:9094";
+            public String getNetworkBootstrapControllers() {
+                return "CONTROLLER://broker-0:9094";
             }
         };
 
@@ -370,7 +370,7 @@ public class StrimziKafkaContainerMockTest {
             "BROKER1://broker-0:9091," +
             "BROKER2://broker-0:9090," +
             "BROKER3://broker-0:9089," +
-            "CONTROLLER://localhost:9094";
+            "CONTROLLER://broker-0:9094";
 
         assertThat(listenersConfig[0], is(expectedListeners));
         assertThat(listenersConfig[1], is(expectedAdvertisedListeners));
@@ -624,6 +624,39 @@ public class StrimziKafkaContainerMockTest {
 
         assertThat(listenersConfig[0], is(expectedListeners));
         assertThat(listenersConfig[1], is(expectedAdvertisedListeners));
+    }
+
+    @Test
+    void testBuildListenersConfigControllerOnlyNode() {
+        InspectContainerResponse containerInfo = Mockito.mock(InspectContainerResponse.class);
+        NetworkSettings networkSettings = Mockito.mock(NetworkSettings.class);
+        Mockito.when(containerInfo.getNetworkSettings()).thenReturn(networkSettings);
+
+        Map<String, ContainerNetwork> networks = new LinkedHashMap<>();
+        ContainerNetwork containerNetwork = Mockito.mock(ContainerNetwork.class);
+        networks.put("bridge", containerNetwork);
+        Mockito.when(networkSettings.getNetworks()).thenReturn(networks);
+
+        kafkaContainer = new StrimziKafkaContainer() {
+            @Override
+            public String getNetworkBootstrapControllers() {
+                return "CONTROLLER://broker-1:9094";
+            }
+        };
+        kafkaContainer.withNodeId(1)
+            .withNodeRole(KafkaNodeRole.CONTROLLER);
+
+        String[] listenersConfig = kafkaContainer.buildListenersConfig(containerInfo);
+
+        String expectedListeners = "CONTROLLER://0.0.0.0:9094";
+        String expectedAdvertisedListeners = ",CONTROLLER://broker-1:9094";
+
+        assertThat(listenersConfig[0], is(expectedListeners));
+        assertThat(listenersConfig[1], is(expectedAdvertisedListeners));
+
+        // Verify only CONTROLLER listener is present (no PLAINTEXT, no BROKER)
+        assertThat(kafkaContainer.listeners.size(), is(1));
+        assertTrue(kafkaContainer.listeners.stream().anyMatch(l -> l.name().equals("CONTROLLER")));
     }
 
     @BeforeEach

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaContainerMockTest.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaContainerMockTest.java
@@ -642,21 +642,26 @@ public class StrimziKafkaContainerMockTest {
             public String getNetworkBootstrapControllers() {
                 return "CONTROLLER://broker-1:9094";
             }
+            @Override
+            public String getBootstrapControllers() {
+                return "CONTROLLER_EXTERNAL://localhost:39095";
+            }
         };
         kafkaContainer.withNodeId(1)
             .withNodeRole(KafkaNodeRole.CONTROLLER);
 
         String[] listenersConfig = kafkaContainer.buildListenersConfig(containerInfo);
 
-        String expectedListeners = "CONTROLLER://0.0.0.0:9094";
-        String expectedAdvertisedListeners = ",CONTROLLER://broker-1:9094";
+        String expectedListeners = "CONTROLLER://0.0.0.0:9094,CONTROLLER_EXTERNAL://0.0.0.0:9095";
+        String expectedAdvertisedListeners = "CONTROLLER://broker-1:9094,CONTROLLER_EXTERNAL://localhost:39095";
 
         assertThat(listenersConfig[0], is(expectedListeners));
         assertThat(listenersConfig[1], is(expectedAdvertisedListeners));
 
-        // Verify only CONTROLLER listener is present (no PLAINTEXT, no BROKER)
-        assertThat(kafkaContainer.listeners.size(), is(1));
+        // Verify both CONTROLLER and CONTROLLER_EXTERNAL listeners are present
+        assertThat(kafkaContainer.listeners.size(), is(2));
         assertTrue(kafkaContainer.listeners.stream().anyMatch(l -> l.name().equals("CONTROLLER")));
+        assertTrue(kafkaContainer.listeners.stream().anyMatch(l -> l.name().equals("CONTROLLER_EXTERNAL")));
     }
 
     @BeforeEach

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaContainerTest.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaContainerTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -727,13 +728,23 @@ class StrimziKafkaContainerTest {
     }
 
     @Test
-    void testExtractControllerListenerMultipleControllersPicksFirst() {
+    void testExtractControllerListenerExtractsBothControllerListeners() {
+        Properties props = new Properties();
+        String adv = "CONTROLLER://broker-1:9094,CONTROLLER_EXTERNAL://localhost:39095";
+
+        kafkaContainer.extractControllerListener(props, adv);
+
+        assertThat(props.getProperty("advertised.listeners"), is("CONTROLLER://broker-1:9094,CONTROLLER_EXTERNAL://localhost:39095"));
+    }
+
+    @Test
+    void testExtractControllerListenerMultipleControllersPicksBoth() {
         Properties props = new Properties();
         String adv = "CONTROLLER://broker-1:9094,CONTROLLER://broker-2:9094";
 
         kafkaContainer.extractControllerListener(props, adv);
 
-        assertThat(props.getProperty("advertised.listeners"), is("CONTROLLER://broker-1:9094"));
+        assertThat(props.getProperty("advertised.listeners"), is("CONTROLLER://broker-1:9094,CONTROLLER://broker-2:9094"));
     }
 
     @Test
@@ -765,6 +776,23 @@ class StrimziKafkaContainerTest {
     }
 
     @Test
+    void testSetKRaftPropertiesControllerOnlyNodeHasDualControllerListenerNames() {
+        StrimziKafkaContainer container = new StrimziKafkaContainer()
+            .withNodeRole(KafkaNodeRole.CONTROLLER)
+            .withNodeId(0);
+
+        container.listeners.add(new StrimziKafkaContainer.ListenerConfig("CONTROLLER", StrimziKafkaContainer.ListenerRole.CONTROLLER));
+        container.listeners.add(new StrimziKafkaContainer.ListenerConfig("CONTROLLER_EXTERNAL", StrimziKafkaContainer.ListenerRole.CONTROLLER));
+
+        Properties properties = container.buildDefaultServerProperties(
+            "CONTROLLER://0.0.0.0:9094,CONTROLLER_EXTERNAL://0.0.0.0:9095",
+            "CONTROLLER://broker-0:9094,CONTROLLER_EXTERNAL://localhost:39095"
+        );
+
+        assertThat(properties.getProperty("controller.listener.names"), is("CONTROLLER,CONTROLLER_EXTERNAL"));
+    }
+
+    @Test
     void testSetKRaftPropertiesWithExistingControllerQuorumVoters() {
         Map<String, String> kafkaConfig = Map.of("controller.quorum.voters", "1@custom:9094");
         StrimziKafkaContainer container = new StrimziKafkaContainer()
@@ -773,16 +801,16 @@ class StrimziKafkaContainerTest {
             .withNodeId(1)
             .withNodeId(1);
         container.listeners.add(new StrimziKafkaContainer.ListenerConfig("PLAINTEXT", StrimziKafkaContainer.ListenerRole.CLIENT));
-        
+
         Properties defaultProps = container.buildDefaultServerProperties(
-            "PLAINTEXT://0.0.0.0:9092", 
+            "PLAINTEXT://0.0.0.0:9092",
             "PLAINTEXT://localhost:9092"
         );
-        
+
         // The buildDefaultServerProperties should skip setting default quorum voters when already configured
         // This tests the conditional: if (this.kafkaConfigurationMap == null || !this.kafkaConfigurationMap.containsKey("controller.quorum.voters"))
         assertThat(defaultProps.getProperty("controller.quorum.voters"), nullValue());
-        
+
         // Test that the override happens during overrideProperties
         String finalProperties = container.overrideProperties(defaultProps, kafkaConfig);
         assertThat(finalProperties, containsString("controller.quorum.voters=1@custom\\:9094"));
@@ -795,7 +823,7 @@ class StrimziKafkaContainerTest {
             .withNodeId(1);
 
         String bootstrapControllers = kafkaContainer.getBootstrapControllers();
-        assertThat(bootstrapControllers, startsWith("CONTROLLER://"));
+        assertThat(bootstrapControllers, startsWith("CONTROLLER_EXTERNAL://"));
     }
 
     @Test
@@ -896,6 +924,26 @@ class StrimziKafkaContainerTest {
     }
 
     @Test
+    void testEnsureControllerMappingIncludesExternalForControllerOnlyNode() {
+        StrimziKafkaContainer controllerContainer = new StrimziKafkaContainer()
+            .withNodeRole(KafkaNodeRole.CONTROLLER)
+            .withNodeId(1);
+
+        controllerContainer.listeners.add(new StrimziKafkaContainer.ListenerConfig("CONTROLLER", StrimziKafkaContainer.ListenerRole.CONTROLLER));
+        controllerContainer.listeners.add(new StrimziKafkaContainer.ListenerConfig("CONTROLLER_EXTERNAL", StrimziKafkaContainer.ListenerRole.CONTROLLER));
+
+        Properties properties = controllerContainer.buildDefaultServerProperties(
+            "CONTROLLER://0.0.0.0:9094,CONTROLLER_EXTERNAL://0.0.0.0:9095",
+            "CONTROLLER://broker-1:9094,CONTROLLER_EXTERNAL://localhost:39095"
+        );
+
+        String listenerSecurityProtocolMap = properties.getProperty("listener.security.protocol.map");
+
+        assertThat(listenerSecurityProtocolMap, containsString("CONTROLLER:PLAINTEXT"));
+        assertThat(listenerSecurityProtocolMap, containsString("CONTROLLER_EXTERNAL:PLAINTEXT"));
+    }
+
+    @Test
     void testEnsureControllerMappingIsPresent() {
         StrimziKafkaContainer controllerContainer = new StrimziKafkaContainer()
             .withNodeRole(KafkaNodeRole.CONTROLLER)
@@ -947,7 +995,9 @@ class StrimziKafkaContainerTest {
 
         List<Integer> exposedPorts = container.determineExposedPorts();
 
-        assertThat(exposedPorts, hasItem(StrimziKafkaContainer.CONTROLLER_PORT));
+        // Controller-only nodes only expose the external port (9095), not the internal port (9094)
+        assertThat(exposedPorts, not(hasItem(StrimziKafkaContainer.CONTROLLER_PORT)));
+        assertThat(exposedPorts, hasItem(StrimziKafkaContainer.CONTROLLER_EXTERNAL_PORT));
         assertThat(exposedPorts.contains(StrimziKafkaContainer.KAFKA_PORT), is(false));
     }
 
@@ -986,6 +1036,18 @@ class StrimziKafkaContainerTest {
 
         assertThat(exposedPorts, hasItem(StrimziKafkaContainer.KAFKA_PORT));
         assertThat(exposedPorts, hasItem(8080));
+    }
+
+    @Test
+    void testDetermineExposedPortsControllerOnlyNodeIncludesExternalPort() {
+        StrimziKafkaContainer container = new StrimziKafkaContainer()
+            .withNodeRole(KafkaNodeRole.CONTROLLER);
+
+        List<Integer> ports = container.determineExposedPorts();
+
+        assertThat(ports, not(hasItem(StrimziKafkaContainer.CONTROLLER_PORT)));
+        assertThat(ports, hasItem(StrimziKafkaContainer.CONTROLLER_EXTERNAL_PORT));
+        assertThat(ports, not(hasItem(StrimziKafkaContainer.KAFKA_PORT)));
     }
 
     @Test

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaContainerTest.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaContainerTest.java
@@ -828,7 +828,7 @@ class StrimziKafkaContainerTest {
             .withNodeId(1);
 
         String networkBootstrapControllers = kafkaContainer.getNetworkBootstrapControllers();
-        assertThat(networkBootstrapControllers, is("broker-1:9094"));
+        assertThat(networkBootstrapControllers, is("CONTROLLER://broker-1:9094"));
     }
 
     @Test
@@ -838,7 +838,7 @@ class StrimziKafkaContainerTest {
             .withNodeId(2);
 
         String networkBootstrapControllers = kafkaContainer.getNetworkBootstrapControllers();
-        assertThat(networkBootstrapControllers, is("broker-2:9094"));
+        assertThat(networkBootstrapControllers, is("CONTROLLER://broker-2:9094"));
     }
 
     @Test


### PR DESCRIPTION
Closing #200. Note that everything worked with combined-mode. This is fix change for dedicated roles and also I saw that for consistency getNetworkBootstrapServers and getNetworkBootstrapControllers now returns prefix listener names `CONTROLLER:` or `PLAINTEXT:`. 