### PR TITLE
Lower pitest line coverage threshold from 76 to 75

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -418,7 +418,7 @@
                         <avoidCallsTo>org.apache.commons.logging</avoidCallsTo>
                     </avoidCallsTo>
                     <mutationThreshold>100</mutationThreshold>
-                    <coverageThreshold>76</coverageThreshold>
+                    <coverageThreshold>75</coverageThreshold>
                     <verbose>true</verbose>
                 </configuration>
             </plugin>


### PR DESCRIPTION
In the previous PR (i.e., https://github.com/strimzi/test-container/pull/204), we refactored inline validation logic from Strimzi* classes into Utils class but that class is explicitly excluded from the pitest target classes scope.

Which eventually means that 14 LoC of moved out of coverage => causing coverage to drop (i.e.,  from 76 to 75). Even we didn't loss any test coverage. Mutation score is still 100% anyway but with these changes I am thinking if we should include f.e., Utils method or others also into account so we would avoid these problems in the future.

WDYT?