### PR TITLE
Add method to retrieve latest patch versions for Kafka minor releases

### DIFF
--- a/src/main/java/io/strimzi/test/container/KafkaVersionService.java
+++ b/src/main/java/io/strimzi/test/container/KafkaVersionService.java
@@ -201,6 +201,32 @@ class KafkaVersionService {
     }
 
     /**
+     * Get list of the latest patch release for each minor version.
+     * For example, if supported versions are [3.7.0, 3.7.1, 4.0.0, 4.0.1, 4.1.0],
+     * this returns [3.7.1, 4.0.1, 4.1.0].
+     *
+     * @return list of version strings representing the latest patch per minor, sorted from oldest to newest
+     */
+    public List<String> getLatestPatchVersions() {
+        return getLatestPatchVersions(this.logicalKafkaVersionEntities);
+    }
+
+    static List<String> getLatestPatchVersions(List<KafkaVersion> versions) {
+        return versions.stream()
+            .collect(Collectors.toMap(
+                kv -> {
+                    String[] parts = kv.getVersion().split("\\.");
+                    return parts[0] + "." + parts[1];
+                },
+                KafkaVersion::getVersion,
+                (existing, candidate) -> KafkaVersion.compareVersions(existing, candidate) >= 0 ? existing : candidate
+            ))
+            .values().stream()
+            .sorted(KafkaVersion::compareVersions)
+            .collect(Collectors.toList());
+    }
+
+    /**
      * Get the latest release where the result is intentionally not deterministic.
      * It's the released test-container-images image with the highest Kafka version number.
      * The result will change when a new version of Kafka is released with a higher Kafka version number,

--- a/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
+++ b/src/main/java/io/strimzi/test/container/StrimziKafkaCluster.java
@@ -1000,6 +1000,18 @@ public class StrimziKafkaCluster implements KafkaContainer {
     }
 
     /**
+     * Get list of the latest patch release for each minor version.
+     * For example, if supported versions are [3.7.0, 3.7.1, 4.0.0, 4.0.1, 4.1.0],
+     * this returns [3.7.1, 4.0.1, 4.1.0].
+     * Useful as a {@code @MethodSource} to run integration tests only against representative versions.
+     *
+     * @return list of version strings representing the latest patch per minor, sorted from oldest to newest
+     */
+    public static List<String> getLatestPatchVersions() {
+        return KafkaVersionService.getInstance().getLatestPatchVersions();
+    }
+
+    /**
      * Retrieves the Proxy instance for a specific node by its node ID.
      * Works for both brokers and controllers.
      *

--- a/src/test/java/io/strimzi/test/container/KafkaVersionServiceTest.java
+++ b/src/test/java/io/strimzi/test/container/KafkaVersionServiceTest.java
@@ -111,4 +111,19 @@ public class KafkaVersionServiceTest {
         assertThat("Supported versions should contain the latest release",
             versions.contains(latestVersion), CoreMatchers.is(true));
     }
+
+    @Test
+    void testGetLatestPatchVersionsHasOneVersionPerMinor() {
+        List<KafkaVersionService.KafkaVersion> input = List.of(
+            new KafkaVersionService.KafkaVersion("3.7.0", "img1"),
+            new KafkaVersionService.KafkaVersion("3.7.1", "img2"),
+            new KafkaVersionService.KafkaVersion("3.8.0", "img3"),
+            new KafkaVersionService.KafkaVersion("3.8.2", "img4"),
+            new KafkaVersionService.KafkaVersion("3.8.1", "img5")
+        );
+
+        List<String> result = KafkaVersionService.getLatestPatchVersions(input);
+
+        assertThat(result, CoreMatchers.is(List.of("3.7.1", "3.8.2")));
+    }
 }

--- a/src/test/java/io/strimzi/test/container/KafkaVersionServiceTest.java
+++ b/src/test/java/io/strimzi/test/container/KafkaVersionServiceTest.java
@@ -113,6 +113,14 @@ public class KafkaVersionServiceTest {
     }
 
     @Test
+    void testGetLatestPatchVersionsReturnsNonEmptyList() {
+        List<String> versions = KafkaVersionService.getInstance().getLatestPatchVersions();
+
+        assertThat(versions, CoreMatchers.notNullValue());
+        assertThat(versions.isEmpty(), CoreMatchers.is(false));
+    }
+
+    @Test
     void testGetLatestPatchVersionsHasOneVersionPerMinor() {
         List<KafkaVersionService.KafkaVersion> input = List.of(
             new KafkaVersionService.KafkaVersion("3.7.0", "img1"),


### PR DESCRIPTION
Closes #215

### Summary
  
- Add `getLatestPatchVersions()` to `StrimziKafkaCluster` as a public API, which returns the latest patch release for each minor version (e.g. [3.7.1, 4.0.1, 4.1.0])
- Extract the core filtering logic into a package-private static method in `KafkaVersionService` to allow unit testing with controlled input
- Add unit test with a fixed set of versions to verify that only the latest patch per minor is returned

### Test plan

- `KafkaVersionServiceTest#testGetLatestPatchVersionsHasOneVersionPerMinor` — verifies the filtering logic with a controlled input list, independent of the real `kafka_versions.json`