### PR TITLE
Remove specific assertion from the TLS test case

### DIFF
--- a/src/test/java/io/strimzi/test/container/StrimziKafkaClusterIT.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaClusterIT.java
@@ -1163,14 +1163,12 @@ public class StrimziKafkaClusterIT extends AbstractIT {
 
         // The internal listener requires mTLS and its truststore only contains
         // the cluster CA. The client cert is signed by the clients CA, so the
-        // SSL handshake should fail with a bad_certificate alert.
+        // SSL handshake should fail.
         assertThat("Client cert signed by clients CA should be rejected by "
                 + "internal listener that only trusts cluster CA",
             result.getExitCode(), is(not(0)));
         assertThat("Should fail due to SSL authentication",
             output, CoreMatchers.containsString("SslAuthenticationException"));
-        assertThat("Should receive bad_certificate alert from broker",
-            output, CoreMatchers.containsString("bad_certificate"));
     }
 
     private void configureTlsForClient(Map<String, Object> config, Path truststorePath, Path clientKeystorePath, String password) {


### PR DESCRIPTION
We only assert on SslAuthenticationException (not the specific alert string) because [JDK-8311644](https://bugs.openjdk.org/browse/JDK-8311644) changed the TLS alert from `bad_certificate` to the RFC-correct value, and the exact wording differs across JDK versions and TLS protocol versions.