### PR TITLE
Update testcontainers-keycloak Version to v4.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <jupiter.version>5.11.4</jupiter.version>
         <hamcrest.version>2.2</hamcrest.version>
         <maven-surefire-failsafe-plugin.version>3.1.2</maven-surefire-failsafe-plugin.version>
-        <testcontainers-keycloak.version>4.0.0</testcontainers-keycloak.version>
+        <testcontainers-keycloak.version>4.2.1</testcontainers-keycloak.version>
         <fasterxml.jackson-annotations.version>2.16.2</fasterxml.jackson-annotations.version>
         <kafka-oauth-client.version>0.17.1</kafka-oauth-client.version>
         <mockito.version>5.17.0</mockito.version>


### PR DESCRIPTION
Update the testcontainers-keycloak version according to: https://github.com/strimzi/test-container/issues/208.

The integration test has been conducted locally.

```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Strimzi - Apache Kafka on Kubernetes and OpenShift 1.1.0-SNAPSHOT:
[INFO]
[INFO] Strimzi - Apache Kafka on Kubernetes and OpenShift . SUCCESS [  0.875 s]
[INFO] Kafka HTTP Agent ................................... SUCCESS [  2.874 s]
[INFO] Tracing Agent ...................................... SUCCESS [  0.102 s]
[INFO] Strimzi test utilities ............................. SUCCESS [  0.103 s]
[INFO] Strimzi CRD annotations ............................ SUCCESS [  0.467 s]
[INFO] Strimzi CRD generator .............................. SUCCESS [  1.817 s]
[INFO] Strimzi API ........................................ SUCCESS [01:24 min]
[INFO] Kubernetes Mock .................................... SUCCESS [  5.216 s]
[INFO] Kafka Configuration Model .......................... SUCCESS [  0.486 s]
[INFO] Kafka Configuration Model generator ................ SUCCESS [  5.680 s]
[INFO] Strimzi Certificates Manager ....................... SUCCESS [  1.069 s]
[INFO] Strimzi operators common logic ..................... SUCCESS [ 38.824 s]
[INFO] Strimzi Topic Operator ............................. SUCCESS [05:36 min]
[INFO] Strimzi Cluster Operator ........................... SUCCESS [13:13 min]
[INFO] Strimzi User Operator .............................. SUCCESS [ 36.993 s]
[INFO] Kafka Init Container application ................... SUCCESS [  1.877 s]
[INFO] Strimzi system tests ............................... SUCCESS [  0.775 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  21:51 min
[INFO] Finished at: 2026-06-01T19:57:00+08:00
[INFO] ------------------------------------------------------------------------
```