### PR TITLE
Skip ITs on release branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,12 +36,18 @@ jobs:
         with:
           javaVersion: ${{ matrix.java.version }}
 
+      # On release branches, skip ITs and run only unit tests and mutation testing.
+      # ITs cannot run here because release candidates use -rc1 suffix tags
+      # and inside the repo we are always preparing GA version without the suffix
+      # that may not have published container images yet.
       - name: Build binaries using build-binaries action
         uses: strimzi/github-actions/.github/actions/build/build-binaries@v1
         with:
           mainJavaBuild: ${{ matrix.java.mainBuild }}
           artifactSuffix: "strimzi-test-container"
           clusterOperatorBuild: "false"
+        env:
+          MVN_ARGS: ${{ startsWith(github.ref, 'refs/heads/release-') && '-B -DskipITs' || '' }}
   
   deploy-java:
     name: Deploy Java artifacts to Maven Central


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR adds a condition where to run ITs. Currently we run it also on release branches but that would fail because such images are not present (GAs ones) as we are doing release candidates.

We can't run ITs in the `release-*` branches as we build images in separate repository.

### Checklist

- [x] Update documentation
- [ ] Update CHANGELOG.md (if present)
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Try your changes inside a Kubernetes cluster, not just from unit tests
- [ ] AI assistance was used to create this PR
