### PR TITLE
Include mutation testing in the test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -400,6 +400,15 @@
                         <version>${pit-junit-plugin.version}</version>
                     </dependency>
                 </dependencies>
+                <executions>
+                    <execution>
+                        <id>mutation-testing</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>mutationCoverage</goal>
+                        </goals>
+                    </execution>
+                </executions>
                 <configuration>
                     <targetClasses>
                         <!-- we not want to include also WaitException, Utils, KafkaVersionService because we mainly

--- a/src/test/java/io/strimzi/test/container/StrimziKafkaClusterTest.java
+++ b/src/test/java/io/strimzi/test/container/StrimziKafkaClusterTest.java
@@ -1310,6 +1310,14 @@ public class StrimziKafkaClusterTest {
     }
 
     @Test
+    void testGetLatestPatchVersionsReturnsNonEmptyList() {
+        List<String> versions = StrimziKafkaCluster.getLatestPatchVersions();
+
+        assertThat(versions, is(CoreMatchers.notNullValue()));
+        assertThat(versions.isEmpty(), is(false));
+    }
+
+    @Test
     void testGetNetworkBootstrapControllersWithDedicatedRoles() {
         StrimziKafkaCluster cluster = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
             .withNumberOfBrokers(2)


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

This PR adds mutation testing in the test scope as it seems that when migrating to GHA, we forgot to add that. By default it run only Azure pipelines. This should solve this as it would run after UTs so the flow would be:

UTs -> mutation tests -> ITs.

### Checklist

- [ ] Update documentation
- [ ] Update CHANGELOG.md (if present)
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Try your changes inside a Kubernetes cluster, not just from unit tests
- [ ] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
