### PR TITLE
Allow only run release job from tags and not any commit from release-…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   release-artifacts:
     name: Release Test-Container artifacts to Maven Central
-    if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
…* branches

### Type of change

- Bugfix

### Description

This PR follows the test-container-images ([1]) as the release job should be triggered only and only from tags (i.e., 0.200.0-rc1).

 [1] - https://github.com/strimzi/test-container-images/blame/2a0e25dd968863691fd7c8f14ce6faeb7ba3a97b/.github/workflows/release.yml#L18

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update documentation
- [ ] Update CHANGELOG.md (if present)
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Try your changes inside a Kubernetes cluster, not just from unit tests
- [ ] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
