### PR TITLE
Correct the release artifacts name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ release_json:
 .PHONY: release_package
 release_package: java_package
 	echo "Creating release archives ..."
-	tar -czf target/$(PROJECT_NAME)-$(RELEASE_VERSION).tar.gz -C target $(PROJECT_NAME)-$(RELEASE_VERSION).jar
-	cd target && zip $(PROJECT_NAME)-$(RELEASE_VERSION).zip $(PROJECT_NAME)-$(RELEASE_VERSION).jar
+	tar -czf target/$(PROJECT_NAME)-$(shell echo $(RELEASE_VERSION) | tr a-z A-Z).tar.gz -C target $(PROJECT_NAME)-$(shell echo $(RELEASE_VERSION) | tr a-z A-Z).jar
+	cd target && zip $(PROJECT_NAME)-$(shell echo $(RELEASE_VERSION) | tr a-z A-Z).zip $(PROJECT_NAME)-$(shell echo $(RELEASE_VERSION) | tr a-z A-Z).jar
 
 .PHONY: clean
 clean: java_clean

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ include ./Makefile.os
 include ./Makefile.maven
 
 RELEASE_VERSION ?= latest
+RELEASE_VERSION_UPPERCASE = $(shell echo $(RELEASE_VERSION) | tr a-z A-Z)
 PROJECT_NAME ?= strimzi-test-container
 
 .PHONY: all
@@ -13,7 +14,7 @@ release: release_maven release_json release_package
 .PHONY: release_maven
 release_maven:
 	echo "Update pom versions to $(RELEASE_VERSION)"
-	mvn $(MVN_ARGS) versions:set -DnewVersion=$(shell echo $(RELEASE_VERSION) | tr a-z A-Z)
+	mvn $(MVN_ARGS) versions:set -DnewVersion=$(RELEASE_VERSION_UPPERCASE)
 	mvn $(MVN_ARGS) versions:commit
 
 .PHONY: release_json
@@ -24,8 +25,8 @@ release_json:
 .PHONY: release_package
 release_package: java_package
 	echo "Creating release archives ..."
-	tar -czf target/$(PROJECT_NAME)-$(shell echo $(RELEASE_VERSION) | tr a-z A-Z).tar.gz -C target $(PROJECT_NAME)-$(shell echo $(RELEASE_VERSION) | tr a-z A-Z).jar
-	cd target && zip $(PROJECT_NAME)-$(shell echo $(RELEASE_VERSION) | tr a-z A-Z).zip $(PROJECT_NAME)-$(shell echo $(RELEASE_VERSION) | tr a-z A-Z).jar
+	tar -czf target/$(PROJECT_NAME)-$(RELEASE_VERSION_UPPERCASE).tar.gz -C target $(PROJECT_NAME)-$(RELEASE_VERSION_UPPERCASE).jar
+	cd target && zip $(PROJECT_NAME)-$(RELEASE_VERSION_UPPERCASE).zip $(PROJECT_NAME)-$(RELEASE_VERSION_UPPERCASE).jar
 
 .PHONY: clean
 clean: java_clean


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fixes the 
```java
[INFO] ------------------------------------------------------------------------
echo "Creating release archives ..."
Creating release archives ...
tar -czf target/strimzi-test-container-0.116.0-rc1.tar.gz -C target strimzi-test-container-0.116.0-rc1.jar
tar: strimzi-test-container-0.116.0-rc1.jar: Cannot stat: No such file or directory
tar: Exiting with failure status due to previous errors
make: *** [Makefile:27: release_package] Error 2
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update documentation
- [ ] Update CHANGELOG.md (if present)
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Try your changes inside a Kubernetes cluster, not just from unit tests
- [ ] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
