### PR TITLE
Add all classes into coverage calculation and introduce precision threshold to avoid blind spot problem

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,8 +124,8 @@
         <maven.checkstyle.version>3.5.0</maven.checkstyle.version>
         <maven.gpg.version>1.6</maven.gpg.version>
         <central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
-        <pit-junit-plugin.version>1.2.1</pit-junit-plugin.version>
-        <pit-plugin.version>1.18.1</pit-plugin.version>
+        <pit-junit-plugin.version>1.2.2</pit-junit-plugin.version>
+        <pit-plugin.version>1.25.4</pit-plugin.version>
 
         <junit4.version>4.13.2</junit4.version>
 
@@ -410,24 +410,21 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <targetClasses>
-                        <!-- we not want to include also WaitException, Utils, KafkaVersionService because we mainly
-                            focus mutation core classes (i.e., Strimzi*, KafkaContainer) -->
-                        <param>io.strimzi.test.container.Strimzi*</param>
-                        <param>io.strimzi.test.container.KafkaContainer</param>
-                    </targetClasses>
                     <targetTests>
-                        <!-- include just UTs within mutation and prevent image pulling -->
-                        <param>io.strimzi.test.container.Strimzi*Test</param>
+                        <param>io.strimzi.test.container.*Test</param>
                     </targetTests>
+                    <excludedTestClasses>
+                        <param>io.strimzi.test.container.*IT</param>
+                    </excludedTestClasses>
                     <avoidCallsTo>
                         <avoidCallsTo>java.util.logging</avoidCallsTo>
                         <avoidCallsTo>org.apache.log4j</avoidCallsTo>
                         <avoidCallsTo>org.slf4j</avoidCallsTo>
                         <avoidCallsTo>org.apache.commons.logging</avoidCallsTo>
                     </avoidCallsTo>
-                    <mutationThreshold>100</mutationThreshold>
-                    <coverageThreshold>75</coverageThreshold>
+                    <mutationThreshold>78.58824</mutationThreshold>
+                    <coverageThreshold>61.99543</coverageThreshold>
+                    <thresholdPrecision>5</thresholdPrecision>
                     <verbose>true</verbose>
                 </configuration>
             </plugin>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR address two issues:

1. Integer thresholds create a blind spot of up to one full percentage point where coverage can silently regress without failing the build. The --thresholdPrecision parameter enables decimal thresholds, dramatically shrinking this blind spot and catching regressions that integer rounding would mask.
2. And closing https://github.com/strimzi/test-container/issues/217 (TL;DR; => we should target all classes and not specific as we did :
```bash
targetClasses>
  <!-- we not want to include also WaitException, Utils, KafkaVersionService because we mainly
      focus mutation core classes (i.e., Strimzi*, KafkaContainer) -->
   <param>io.strimzi.test.container.Strimzi*</param>
   <param>io.strimzi.test.container.KafkaContainer</param>
</targetClasses>
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update documentation
- [ ] Update CHANGELOG.md (if present)
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Try your changes inside a Kubernetes cluster, not just from unit tests
- [ ] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
