### PR TITLE
Run ITs and UTs within release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
           releaseVersion: ${{ inputs.releaseVersion }}
           artifactSuffix: "strimzi-test-container"
 
+      # deploy-java skips tests, and build workflow can not run them on release branches
+      # because RC images are not published yet. Here, kafka_versions.json is already
+      # updated with the releaseVersion, so tests run against the correct images.
       - name: Run tests
         run: mvn -B verify
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
           releaseVersion: ${{ inputs.releaseVersion }}
           artifactSuffix: "strimzi-test-container"
 
+      - name: Run tests
+        run: mvn -B verify
+
       - uses: strimzi/github-actions/.github/actions/build/deploy-java@v1
         with:
           gpgPassphrase: ${{ secrets.GPG_PASSPHRASE }}


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation
- Dependency update
- Task

### Description

This PR adds a step into release job. Currently ITs and UTs are skipped in the release job in both actions (i.e., release-artifacts and deploy-java) so we need somehow to trigger ITs and UTs to verify images produced in the test-container-images repository. This additional step should solve it. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update documentation
- [ ] Update CHANGELOG.md (if present)
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Try your changes inside a Kubernetes cluster, not just from unit tests
- [ ] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
